### PR TITLE
Add models and services (Project, Session, Report)

### DIFF
--- a/RockyCore/Sources/RockyCore/Models/Project.swift
+++ b/RockyCore/Sources/RockyCore/Models/Project.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SQLiteNIO
+
+public struct Project: Sendable {
+    public let id: Int
+    public let parentId: Int?
+    public let name: String
+    public let createdAt: Date
+
+    public init(id: Int, parentId: Int?, name: String, createdAt: Date) {
+        self.id = id
+        self.parentId = parentId
+        self.name = name
+        self.createdAt = createdAt
+    }
+
+    public init(row: SQLiteRow) throws {
+        guard let id = row.column("id")?.integer,
+              let name = row.column("name")?.string,
+              let createdAtStr = row.column("created_at")?.string else {
+            throw RockyCoreError.invalidRow("project")
+        }
+        self.id = id
+        self.parentId = row.column("parent_id")?.integer
+        self.name = name
+        self.createdAt = try DateFormatter.sqlite.parseOrThrow(createdAtStr)
+    }
+}
+
+public enum RockyCoreError: Error, CustomStringConvertible {
+    case invalidRow(String)
+    case projectNotFound(String)
+    case timerAlreadyRunning(String)
+    case noRunningTimers
+
+    public var description: String {
+        switch self {
+        case .invalidRow(let table):
+            return "Invalid row data in \(table) table"
+        case .projectNotFound(let name):
+            return "No project found with name \"\(name)\""
+        case .timerAlreadyRunning(let name):
+            return "Timer already running for \(name)"
+        case .noRunningTimers:
+            return "No timers currently running."
+        }
+    }
+}
+
+extension DateFormatter {
+    static let sqlite: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    func parseOrThrow(_ string: String) throws -> Date {
+        guard let date = date(from: string) else {
+            throw RockyCoreError.invalidRow("date parse failed: \(string)")
+        }
+        return date
+    }
+}

--- a/RockyCore/Sources/RockyCore/Models/Session.swift
+++ b/RockyCore/Sources/RockyCore/Models/Session.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SQLiteNIO
+
+public struct Session: Sendable {
+    public let id: Int
+    public let projectId: Int
+    public let startTime: Date
+    public let endTime: Date?
+
+    public init(id: Int, projectId: Int, startTime: Date, endTime: Date?) {
+        self.id = id
+        self.projectId = projectId
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    public init(row: SQLiteRow) throws {
+        guard let id = row.column("id")?.integer,
+              let projectId = row.column("project_id")?.integer,
+              let startTimeStr = row.column("start_time")?.string else {
+            throw RockyCoreError.invalidRow("session")
+        }
+        self.id = id
+        self.projectId = projectId
+        self.startTime = try DateFormatter.sqlite.parseOrThrow(startTimeStr)
+        if let endTimeStr = row.column("end_time")?.string {
+            self.endTime = try DateFormatter.sqlite.parseOrThrow(endTimeStr)
+        } else {
+            self.endTime = nil
+        }
+    }
+
+    public var isRunning: Bool { endTime == nil }
+
+    public func duration(at now: Date = Date()) -> TimeInterval {
+        let end = endTime ?? now
+        return end.timeIntervalSince(startTime)
+    }
+}

--- a/RockyCore/Sources/RockyCore/Services/ProjectService.swift
+++ b/RockyCore/Sources/RockyCore/Services/ProjectService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SQLiteNIO
+
+public struct ProjectService: Sendable {
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    public func findOrCreate(name: String) async throws -> Project {
+        if let existing = try await getByName(name) {
+            return existing
+        }
+        try await db.execute(
+            "INSERT INTO projects (name) VALUES (?)",
+            [.text(name)]
+        )
+        let id = try await db.lastAutoincrementID()
+        let rows = try await db.query(
+            "SELECT * FROM projects WHERE id = ?",
+            [.integer(id)]
+        )
+        return try Project(row: rows[0])
+    }
+
+    public func getByName(_ name: String) async throws -> Project? {
+        let rows = try await db.query(
+            "SELECT * FROM projects WHERE name = ? COLLATE NOCASE",
+            [.text(name)]
+        )
+        guard let row = rows.first else { return nil }
+        return try Project(row: row)
+    }
+
+    public func list() async throws -> [Project] {
+        let rows = try await db.query(
+            "SELECT * FROM projects ORDER BY created_at ASC"
+        )
+        return try rows.map { try Project(row: $0) }
+    }
+}

--- a/RockyCore/Sources/RockyCore/Services/ReportService.swift
+++ b/RockyCore/Sources/RockyCore/Services/ReportService.swift
@@ -1,0 +1,265 @@
+import Foundation
+import SQLiteNIO
+
+public struct ReportService: Sendable {
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    // MARK: - Status (no flags)
+
+    public func allProjectsWithStatus() async throws -> [ProjectStatus] {
+        let rows = try await db.query("""
+            SELECT p.*,
+                   s.id AS s_id, s.start_time AS s_start_time, s.end_time AS s_end_time,
+                   (SELECT MAX(s2.end_time) FROM sessions s2 WHERE s2.project_id = p.id) AS last_active
+            FROM projects p
+            LEFT JOIN sessions s ON s.project_id = p.id AND s.end_time IS NULL
+            ORDER BY
+                CASE WHEN s.id IS NOT NULL THEN 0 ELSE 1 END,
+                s.start_time ASC,
+                last_active DESC,
+                p.created_at DESC
+            """)
+
+        var seen = Set<Int>()
+        var results: [ProjectStatus] = []
+        for row in rows {
+            let project = try Project(row: row)
+            if seen.contains(project.id) { continue }
+            seen.insert(project.id)
+
+            var runningSession: Session? = nil
+            if let sId = row.column("s_id")?.integer,
+               let sStartStr = row.column("s_start_time")?.string {
+                runningSession = Session(
+                    id: sId,
+                    projectId: project.id,
+                    startTime: try DateFormatter.sqlite.parseOrThrow(sStartStr),
+                    endTime: nil
+                )
+            }
+            results.append(ProjectStatus(project: project, runningSession: runningSession))
+        }
+        return results
+    }
+
+    // MARK: - Time range reports
+
+    public func totals(from: Date, to: Date, projectId: Int? = nil) async throws -> ProjectTotals {
+        let sessionService = SessionService(db: db)
+        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+        let now = Date()
+
+        var projectDurations: [String: TimeInterval] = [:]
+        var projectRunning: [String: Bool] = [:]
+
+        for (session, project) in sessions {
+            let clampedStart = max(session.startTime, from)
+            let clampedEnd = min(session.endTime ?? now, to)
+            let duration = max(0, clampedEnd.timeIntervalSince(clampedStart))
+
+            projectDurations[project.name, default: 0] += duration
+            if session.isRunning {
+                projectRunning[project.name] = true
+            }
+        }
+
+        let entries = projectDurations.map { name, duration in
+            ProjectTotalEntry(
+                projectName: name,
+                duration: duration,
+                isRunning: projectRunning[name] ?? false
+            )
+        }.sorted { a, b in
+            if a.isRunning != b.isRunning { return a.isRunning }
+            return a.duration > b.duration
+        }
+
+        return ProjectTotals(entries: entries)
+    }
+
+    public func groupedByDay(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
+        try await grouped(from: from, to: to, projectId: projectId, grouping: .day)
+    }
+
+    public func groupedByWeek(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
+        try await grouped(from: from, to: to, projectId: projectId, grouping: .week)
+    }
+
+    public func groupedByMonth(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
+        try await grouped(from: from, to: to, projectId: projectId, grouping: .month)
+    }
+
+    private func grouped(from: Date, to: Date, projectId: Int? = nil, grouping: Grouping) async throws -> GroupedReport {
+        let sessionService = SessionService(db: db)
+        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+        let now = Date()
+        let calendar = Calendar.current
+
+        let columns = generateColumns(from: from, to: to, grouping: grouping, calendar: calendar)
+
+        // project name -> column index -> duration
+        var data: [String: [Int: TimeInterval]] = [:]
+        var projectRunning: [String: Bool] = [:]
+
+        for (session, project) in sessions {
+            let clampedStart = max(session.startTime, from)
+            let clampedEnd = min(session.endTime ?? now, to)
+
+            if session.isRunning {
+                projectRunning[project.name] = true
+            }
+
+            // Distribute duration across columns
+            for (i, column) in columns.enumerated() {
+                let overlapStart = max(clampedStart, column.start)
+                let overlapEnd = min(clampedEnd, column.end)
+                if overlapEnd > overlapStart {
+                    let duration = overlapEnd.timeIntervalSince(overlapStart)
+                    data[project.name, default: [:]][i, default: 0] += duration
+                }
+            }
+        }
+
+        let rows = data.map { name, columnDurations in
+            GroupedReportRow(
+                projectName: name,
+                isRunning: projectRunning[name] ?? false,
+                columnDurations: columnDurations
+            )
+        }.sorted { a, b in
+            if a.isRunning != b.isRunning { return a.isRunning }
+            let aTotal = a.columnDurations.values.reduce(0, +)
+            let bTotal = b.columnDurations.values.reduce(0, +)
+            return aTotal > bTotal
+        }
+
+        return GroupedReport(columns: columns.map(\.label), rows: rows)
+    }
+
+    public func verboseSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [VerboseSessionRow] {
+        let sessionService = SessionService(db: db)
+        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+
+        return sessions.map { session, project in
+            VerboseSessionRow(
+                session: session,
+                projectName: project.name
+            )
+        }
+    }
+
+    // MARK: - Column generation
+
+    private func generateColumns(from: Date, to: Date, grouping: Grouping, calendar: Calendar) -> [Column] {
+        var columns: [Column] = []
+        var current = from
+
+        switch grouping {
+        case .day:
+            while current < to {
+                let next = calendar.date(byAdding: .day, value: 1, to: current)!
+                let end = min(next, to)
+                let dayName = dayFormatter.string(from: current)
+                columns.append(Column(label: dayName, start: current, end: end))
+                current = next
+            }
+        case .week:
+            var weekNum = 1
+            while current < to {
+                let next = calendar.date(byAdding: .day, value: 7, to: current)!
+                let end = min(next, to)
+                columns.append(Column(label: "Week \(weekNum)", start: current, end: end))
+                current = next
+                weekNum += 1
+            }
+        case .month:
+            while current < to {
+                let next = calendar.date(byAdding: .month, value: 1, to: current)!
+                let end = min(next, to)
+                let monthName = monthFormatter.string(from: current)
+                columns.append(Column(label: monthName, start: current, end: end))
+                current = next
+            }
+        }
+        return columns
+    }
+
+    private var dayFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.dateFormat = "EEE"
+        return f
+    }
+
+    private var monthFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.dateFormat = "MMM"
+        return f
+    }
+}
+
+// MARK: - Types
+
+public struct ProjectStatus: Sendable {
+    public let project: Project
+    public let runningSession: Session?
+
+    public var isRunning: Bool { runningSession != nil }
+}
+
+public struct ProjectTotals: Sendable {
+    public let entries: [ProjectTotalEntry]
+
+    public var total: TimeInterval {
+        entries.reduce(0) { $0 + $1.duration }
+    }
+}
+
+public struct ProjectTotalEntry: Sendable {
+    public let projectName: String
+    public let duration: TimeInterval
+    public let isRunning: Bool
+}
+
+public struct GroupedReport: Sendable {
+    public let columns: [String]
+    public let rows: [GroupedReportRow]
+
+    public func columnTotal(_ index: Int) -> TimeInterval {
+        rows.reduce(0) { $0 + ($1.columnDurations[index] ?? 0) }
+    }
+
+    public var grandTotal: TimeInterval {
+        rows.reduce(0) { total, row in
+            total + row.columnDurations.values.reduce(0, +)
+        }
+    }
+}
+
+public struct GroupedReportRow: Sendable {
+    public let projectName: String
+    public let isRunning: Bool
+    public let columnDurations: [Int: TimeInterval]
+
+    public var total: TimeInterval {
+        columnDurations.values.reduce(0, +)
+    }
+}
+
+public struct VerboseSessionRow: Sendable {
+    public let session: Session
+    public let projectName: String
+}
+
+private enum Grouping {
+    case day, week, month
+}
+
+private struct Column {
+    let label: String
+    let start: Date
+    let end: Date
+}

--- a/RockyCore/Sources/RockyCore/Services/SessionService.swift
+++ b/RockyCore/Sources/RockyCore/Services/SessionService.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SQLiteNIO
+
+public struct SessionService: Sendable {
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    public func start(projectId: Int) async throws {
+        try await db.execute(
+            "INSERT INTO sessions (project_id) VALUES (?)",
+            [.integer(projectId)]
+        )
+    }
+
+    public func hasRunningSession(projectId: Int) async throws -> Bool {
+        let rows = try await db.query(
+            "SELECT id FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
+            [.integer(projectId)]
+        )
+        return !rows.isEmpty
+    }
+
+    public func stop(projectId: Int) async throws -> Session {
+        let rows = try await db.query(
+            "SELECT * FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
+            [.integer(projectId)]
+        )
+        guard let row = rows.first else {
+            throw RockyCoreError.noRunningTimers
+        }
+        let session = try Session(row: row)
+        try await db.execute(
+            "UPDATE sessions SET end_time = datetime('now') WHERE id = ?",
+            [.integer(session.id)]
+        )
+        // Re-fetch to get the end_time
+        let updated = try await db.query(
+            "SELECT * FROM sessions WHERE id = ?",
+            [.integer(session.id)]
+        )
+        return try Session(row: updated[0])
+    }
+
+    public func stopAll() async throws -> [Session] {
+        let running = try await getRunning()
+        var stopped: [Session] = []
+        for session in running {
+            try await db.execute(
+                "UPDATE sessions SET end_time = datetime('now') WHERE id = ?",
+                [.integer(session.id)]
+            )
+            let updated = try await db.query(
+                "SELECT * FROM sessions WHERE id = ?",
+                [.integer(session.id)]
+            )
+            stopped.append(try Session(row: updated[0]))
+        }
+        return stopped
+    }
+
+    public func getRunning() async throws -> [Session] {
+        let rows = try await db.query(
+            "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC"
+        )
+        return try rows.map { try Session(row: $0) }
+    }
+
+    public func getRunningWithProjects() async throws -> [(Session, Project)] {
+        let rows = try await db.query("""
+            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
+            FROM sessions s
+            JOIN projects p ON s.project_id = p.id
+            WHERE s.end_time IS NULL
+            ORDER BY s.start_time ASC
+            """)
+        return try rows.map { row in
+            let session = try Session(row: row)
+            guard let pId = row.column("p_id")?.integer,
+                  let pName = row.column("p_name")?.string,
+                  let pCreatedAtStr = row.column("p_created_at")?.string else {
+                throw RockyCoreError.invalidRow("session+project join")
+            }
+            let project = Project(
+                id: pId,
+                parentId: row.column("p_parent_id")?.integer,
+                name: pName,
+                createdAt: try DateFormatter.sqlite.parseOrThrow(pCreatedAtStr)
+            )
+            return (session, project)
+        }
+    }
+
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
+        let fromStr = DateFormatter.sqlite.string(from: from)
+        let toStr = DateFormatter.sqlite.string(from: to)
+
+        var sql = """
+            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
+            FROM sessions s
+            JOIN projects p ON s.project_id = p.id
+            WHERE (s.start_time < ? AND (s.end_time > ? OR s.end_time IS NULL))
+            """
+        var binds: [SQLiteData] = [.text(toStr), .text(fromStr)]
+
+        if let projectId {
+            sql += " AND s.project_id = ?"
+            binds.append(.integer(projectId))
+        }
+        sql += " ORDER BY s.start_time ASC"
+
+        let rows = try await db.query(sql, binds)
+        return try rows.map { row in
+            let session = try Session(row: row)
+            guard let pId = row.column("p_id")?.integer,
+                  let pName = row.column("p_name")?.string,
+                  let pCreatedAtStr = row.column("p_created_at")?.string else {
+                throw RockyCoreError.invalidRow("session+project join")
+            }
+            let project = Project(
+                id: pId,
+                parentId: row.column("p_parent_id")?.integer,
+                name: pName,
+                createdAt: try DateFormatter.sqlite.parseOrThrow(pCreatedAtStr)
+            )
+            return (session, project)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Project` and `Session` model structs with SQLiteRow parsing
- Implements `ProjectService` (findOrCreate, getByName with case-insensitive matching, list)
- Implements `SessionService` (start, stop, stopAll, getRunning, getSessions with date range + project filter)
- Implements `ReportService` (allProjectsWithStatus, totals, grouped by day/week/month, verbose sessions)
- Adds `RockyCoreError` enum for structured error handling

Closes #2, closes #3, closes #4

## Test plan
- [ ] `swift build` succeeds in RockyCore
- [ ] All service methods handle edge cases (no rows, null end_time, date clamping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)