### PR TITLE
Fix error exit codes to be non-zero

### DIFF
--- a/RockyCLI/Sources/RockyCLI/Commands/Config.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Config.swift
@@ -16,7 +16,7 @@ struct Config: ParsableCommand {
         func run() throws {
             let config = try ConfigFile.load()
             guard let value = config[key] else {
-                throw CleanExit.message("Key \"\(key)\" is not set.")
+                throw ValidationError("Key \"\(key)\" is not set.")
             }
             print("\(key) = \(value)")
         }

--- a/RockyCLI/Sources/RockyCLI/Commands/Start.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Start.swift
@@ -19,7 +19,7 @@ struct Start: AsyncParsableCommand {
         let proj = try await projectService.findOrCreate(name: project)
 
         if try await sessionService.hasRunningSession(projectId: proj.id) {
-            throw CleanExit.message("Timer already running for \(proj.name)")
+            throw ValidationError("Timer already running for \(proj.name)")
         }
 
         try await sessionService.start(projectId: proj.id)

--- a/RockyCLI/Sources/RockyCLI/Commands/Status.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Status.swift
@@ -43,7 +43,7 @@ struct Status: AsyncParsableCommand {
         var projectId: Int? = nil
         if let projectName = project {
             guard let proj = try await projectService.getByName(projectName) else {
-                throw CleanExit.message("No project found with name \"\(projectName)\".")
+                throw ValidationError("No project found with name \"\(projectName)\".")
             }
             projectId = proj.id
         }
@@ -110,12 +110,12 @@ struct Status: AsyncParsableCommand {
 
         if let fromStr = from {
             guard let fromDate = parseDate(fromStr) else {
-                throw CleanExit.message("Invalid date format: \(fromStr). Use YYYY-MM-DD.")
+                throw ValidationError("Invalid date format: \(fromStr). Use YYYY-MM-DD.")
             }
             let toDate: Date
             if let toStr = to {
                 guard let parsed = parseDate(toStr) else {
-                    throw CleanExit.message("Invalid date format: \(toStr). Use YYYY-MM-DD.")
+                    throw ValidationError("Invalid date format: \(toStr). Use YYYY-MM-DD.")
                 }
                 toDate = calendar.date(byAdding: .day, value: 1, to: parsed)!
             } else {

--- a/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
@@ -71,7 +71,7 @@ struct Stop: AsyncParsableCommand {
 
     private func stopProject(name: String, projectService: ProjectService, sessionService: SessionService) async throws {
         guard let proj = try await projectService.getByName(name) else {
-            throw CleanExit.message("No project found with name \"\(name)\".")
+            throw ValidationError("No project found with name \"\(name)\".")
         }
         let stopped = try await sessionService.stop(projectId: proj.id)
         print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")


### PR DESCRIPTION
## Summary
- Replace `CleanExit.message` with `ValidationError` in all error paths
- Errors now exit with code 64 instead of 0

Closes #16

## Test plan
- [x] `rocky stop nonexistent` exits with code 64
- [x] `rocky start <already-running>` exits non-zero
- [x] `rocky status --project nonexistent` exits non-zero
- [x] `rocky config get <unset-key>` exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)