### PR TITLE
Wire auto-stop config into start command

### DIFF
--- a/RockyCLI/Sources/RockyCLI/Commands/Start.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Start.swift
@@ -18,7 +18,8 @@ struct Start: AsyncParsableCommand {
 
         let proj = try await projectService.findOrCreate(name: project)
 
-        if try await sessionService.hasRunningSession(projectId: proj.id) {
+        let autoStop = try ConfigFile.getBool("auto-stop", default: true)
+        if autoStop, try await sessionService.hasRunningSession(projectId: proj.id) {
             throw ValidationError("Timer already running for \(proj.name)")
         }
 


### PR DESCRIPTION
## Summary
- `rocky start` now checks the `auto-stop` config setting before rejecting duplicate timers
- `auto-stop = true` (default): errors if project already has a running timer
- `auto-stop = false`: allows multiple concurrent sessions on the same project

Closes #19

## Test plan
- [x] Default behavior: `rocky start x` twice errors on second call
- [x] `rocky config set auto-stop false` then `rocky start x` twice succeeds
- [x] Builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)