### PR TITLE
Use Duration API for formatting, show seconds, right-align values

### DIFF
--- a/RockyCLI/Sources/RockyCLI/Output/Formatter.swift
+++ b/RockyCLI/Sources/RockyCLI/Output/Formatter.swift
@@ -2,14 +2,36 @@ import Foundation
 
 enum Formatter {
     static func duration(_ seconds: TimeInterval, hoursOnly: Bool = false) -> String {
-        let totalMinutes = Int(seconds) / 60
-        let hours = totalMinutes / 60
-        let minutes = totalMinutes % 60
+        let dur = Duration.seconds(Int(seconds))
 
         if hoursOnly {
-            return "\(hours)h"
+            return dur.formatted(.units(
+                allowed: [.hours],
+                width: .narrow,
+                zeroValueUnits: .show(length: 1),
+                fractionalPart: .hide
+            ))
         }
-        return "\(hours)h \(String(format: "%02d", minutes))m"
+
+        let totalMinutes = Int(seconds) / 60
+        let style: Duration.UnitsFormatStyle
+        if totalMinutes > 0 {
+            style = Duration.UnitsFormatStyle(
+                allowedUnits: [.hours, .minutes],
+                width: .narrow,
+                zeroValueUnits: .show(length: 1),
+                fractionalPart: .hide
+            )
+        } else {
+            style = Duration.UnitsFormatStyle(
+                allowedUnits: [.hours, .seconds],
+                width: .narrow,
+                zeroValueUnits: .show(length: 1),
+                fractionalPart: .hide
+            )
+        }
+        return dur.formatted(style)
+            .replacingOccurrences(of: #" (\d)([ms])"#, with: " 0$1$2", options: .regularExpression)
     }
 
     static func time(_ date: Date) -> String {

--- a/RockyCLI/Sources/RockyCLI/Output/Table.swift
+++ b/RockyCLI/Sources/RockyCLI/Output/Table.swift
@@ -221,7 +221,12 @@ enum Table {
             }
             for (i, cell) in row.cells.enumerated() {
                 if i > 0 { line += "   " }
-                line += cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
+                if i == 0 {
+                    line += cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
+                } else {
+                    let padded = String(repeating: " ", count: max(0, widths[i] - cell.count)) + cell
+                    line += padded
+                }
             }
             return line.trimmingTrailingWhitespace()
         }


### PR DESCRIPTION
## Summary
- Replace manual duration arithmetic with Swift's `Duration.UnitsFormatStyle`
- Sub-minute durations now show seconds (`0h 12s`) instead of `0h 00m`
- All value columns in tables are right-aligned; project names stay left-aligned

Closes #20

## Test plan
- [x] `rocky status` shows seconds for just-started timers
- [x] `rocky status --today/--week/--month/--year` all render correctly
- [x] `rocky status --week --verbose` right-aligns duration column
- [x] Values align cleanly in all table views

🤖 Generated with [Claude Code](https://claude.com/claude-code)