### PR TITLE
Add repository pattern with DI and AppContext

### DIFF
--- a/RockyCLI/Sources/RockyCLI/AppContext.swift
+++ b/RockyCLI/Sources/RockyCLI/AppContext.swift
@@ -1,0 +1,31 @@
+import RockyCore
+
+struct AppContext {
+    let projectService: ProjectService
+    let sessionService: SessionService
+    let reportService: ReportService
+    private let db: Database
+
+    private init(db: Database, projectService: ProjectService, sessionService: SessionService, reportService: ReportService) {
+        self.db = db
+        self.projectService = projectService
+        self.sessionService = sessionService
+        self.reportService = reportService
+    }
+
+    static func build() async throws -> AppContext {
+        let db = try await Database.open()
+        let projectRepo = SQLiteProjectRepository(db: db)
+        let sessionRepo = SQLiteSessionRepository(db: db)
+        return AppContext(
+            db: db,
+            projectService: ProjectService(repository: projectRepo),
+            sessionService: SessionService(repository: sessionRepo),
+            reportService: ReportService(sessionRepository: sessionRepo, projectRepository: projectRepo)
+        )
+    }
+
+    func close() async throws {
+        try await db.close()
+    }
+}

--- a/RockyCLI/Sources/RockyCLI/Commands/Projects.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Projects.swift
@@ -7,11 +7,10 @@ struct Projects: AsyncParsableCommand {
     )
 
     func run() async throws {
-        let db = try await Database.open()
-        defer { Task { try? await db.close() } }
+        let ctx = try await AppContext.build()
+        defer { Task { try? await ctx.close() } }
 
-        let projectService = ProjectService(db: db)
-        let projects = try await projectService.list()
+        let projects = try await ctx.projectService.list()
 
         if projects.isEmpty {
             print("No projects found.")

--- a/RockyCLI/Sources/RockyCLI/Commands/Start.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Start.swift
@@ -10,23 +10,20 @@ struct Start: AsyncParsableCommand {
     var project: String
 
     func run() async throws {
-        let db = try await Database.open()
-        defer { Task { try? await db.close() } }
+        let ctx = try await AppContext.build()
+        defer { Task { try? await ctx.close() } }
 
-        let projectService = ProjectService(db: db)
-        let sessionService = SessionService(db: db)
-
-        let proj = try await projectService.findOrCreate(name: project)
+        let proj = try await ctx.projectService.findOrCreate(name: project)
 
         let autoStop = try ConfigFile.getBool("auto-stop", default: true)
-        if autoStop, try await sessionService.hasRunningSession(projectId: proj.id) {
+        if autoStop, try await ctx.sessionService.hasRunningSession(projectId: proj.id) {
             throw ValidationError("Timer already running for \(proj.name)")
         }
 
-        try await sessionService.start(projectId: proj.id)
+        try await ctx.sessionService.start(projectId: proj.id)
         print("Started \(proj.name)")
 
-        let running = try await sessionService.getRunningWithProjects()
+        let running = try await ctx.sessionService.getRunningWithProjects()
         if running.count > 1 {
             let names = running.map(\.1.name).joined(separator: ", ")
             print("Currently running: \(names)")

--- a/RockyCLI/Sources/RockyCLI/Commands/Status.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Status.swift
@@ -32,17 +32,15 @@ struct Status: AsyncParsableCommand {
     var project: String?
 
     func run() async throws {
-        let db = try await Database.open()
-        defer { Task { try? await db.close() } }
+        let ctx = try await AppContext.build()
+        defer { Task { try? await ctx.close() } }
 
-        let reportService = ReportService(db: db)
-        let projectService = ProjectService(db: db)
         let calendar = Calendar.current
 
         // Resolve project filter
         var projectId: Int? = nil
         if let projectName = project {
-            guard let proj = try await projectService.getByName(projectName) else {
+            guard let proj = try await ctx.projectService.getByName(projectName) else {
                 throw ValidationError("No project found with name \"\(projectName)\".")
             }
             projectId = proj.id
@@ -50,7 +48,7 @@ struct Status: AsyncParsableCommand {
 
         // No time range flags — show current status
         if !today && !week && !month && !year && from == nil {
-            let statuses = try await reportService.allProjectsWithStatus()
+            let statuses = try await ctx.reportService.allProjectsWithStatus()
             print(Table.renderStatus(statuses))
             return
         }
@@ -61,10 +59,10 @@ struct Status: AsyncParsableCommand {
         if today {
             let (start, _) = dayRange(for: now, calendar: calendar)
             if verbose {
-                let sessions = try await reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderVerbose(sessions, period: Formatter.periodToday(), projectFilter: project))
             } else {
-                let totals = try await reportService.totals(from: start, to: endOfToday, projectId: projectId)
+                let totals = try await ctx.reportService.totals(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderTodayTotals(totals, period: Formatter.periodToday()))
             }
             return
@@ -74,10 +72,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = weekRange(for: now, calendar: calendar)
             let period = Formatter.periodRange(from: start, to: endOfToday)
             if verbose {
-                let sessions = try await reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
+                let report = try await ctx.reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
@@ -87,10 +85,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = monthRange(for: now, calendar: calendar)
             let period = Formatter.periodMonth(date: now)
             if verbose {
-                let sessions = try await reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
+                let report = try await ctx.reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
@@ -100,10 +98,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = yearRange(for: now, calendar: calendar)
             let period = Formatter.periodYear(date: now)
             if verbose {
-                let sessions = try await reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
+                let report = try await ctx.reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
             return
@@ -128,16 +126,16 @@ struct Status: AsyncParsableCommand {
             let period = Formatter.periodRange(from: fromDate, to: toDate)
 
             if verbose {
-                let sessions = try await reportService.verboseSessions(from: fromDate, to: toDate, projectId: projectId)
+                let sessions = try await ctx.reportService.verboseSessions(from: fromDate, to: toDate, projectId: projectId)
                 print(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else if days <= 7 {
-                let report = try await reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
+                let report = try await ctx.reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project))
             } else if days <= 60 {
-                let report = try await reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
+                let report = try await ctx.reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project))
             } else {
-                let report = try await reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
+                let report = try await ctx.reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
                 print(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
         }

--- a/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
@@ -14,24 +14,21 @@ struct Stop: AsyncParsableCommand {
     var all: Bool = false
 
     func run() async throws {
-        let db = try await Database.open()
-        defer { Task { try? await db.close() } }
-
-        let projectService = ProjectService(db: db)
-        let sessionService = SessionService(db: db)
+        let ctx = try await AppContext.build()
+        defer { Task { try? await ctx.close() } }
 
         if all {
-            try await stopAll(projectService: projectService, sessionService: sessionService)
+            try await stopAll(ctx: ctx)
             return
         }
 
         if let projectName = project {
-            try await stopProject(name: projectName, projectService: projectService, sessionService: sessionService)
+            try await stopProject(name: projectName, ctx: ctx)
             return
         }
 
         // No args — check running timers
-        let running = try await sessionService.getRunningWithProjects()
+        let running = try await ctx.sessionService.getRunningWithProjects()
 
         if running.isEmpty {
             print("No timers currently running.")
@@ -40,7 +37,7 @@ struct Stop: AsyncParsableCommand {
 
         if running.count == 1 {
             let (_, proj) = running[0]
-            let stopped = try await sessionService.stop(projectId: proj.id)
+            let stopped = try await ctx.sessionService.stop(projectId: proj.id)
             print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
             return
         }
@@ -54,13 +51,13 @@ struct Stop: AsyncParsableCommand {
             guard let input = readLine()?.trimmingCharacters(in: .whitespaces) else { continue }
 
             if input == "all" {
-                try await stopAll(projectService: projectService, sessionService: sessionService)
+                try await stopAll(ctx: ctx)
                 return
             }
 
             if let num = Int(input), num >= 1, num <= running.count {
                 let (_, proj) = running[num - 1]
-                let stopped = try await sessionService.stop(projectId: proj.id)
+                let stopped = try await ctx.sessionService.stop(projectId: proj.id)
                 print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
                 return
             }
@@ -69,16 +66,16 @@ struct Stop: AsyncParsableCommand {
         }
     }
 
-    private func stopProject(name: String, projectService: ProjectService, sessionService: SessionService) async throws {
-        guard let proj = try await projectService.getByName(name) else {
+    private func stopProject(name: String, ctx: AppContext) async throws {
+        guard let proj = try await ctx.projectService.getByName(name) else {
             throw ValidationError("No project found with name \"\(name)\".")
         }
-        let stopped = try await sessionService.stop(projectId: proj.id)
+        let stopped = try await ctx.sessionService.stop(projectId: proj.id)
         print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
     }
 
-    private func stopAll(projectService: ProjectService, sessionService: SessionService) async throws {
-        let stopped = try await sessionService.stopAll()
+    private func stopAll(ctx: AppContext) async throws {
+        let stopped = try await ctx.sessionService.stopAll()
         if stopped.isEmpty {
             print("No timers currently running.")
             return
@@ -86,7 +83,7 @@ struct Stop: AsyncParsableCommand {
 
         var entries: [(name: String, duration: String)] = []
         for session in stopped {
-            if let proj = try await projectService.getById(session.projectId) {
+            if let proj = try await ctx.projectService.getById(session.projectId) {
                 entries.append((proj.name, Formatter.duration(session.duration())))
             }
         }

--- a/RockyCore/Sources/RockyCore/Models/Project.swift
+++ b/RockyCore/Sources/RockyCore/Models/Project.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SQLiteNIO
 
 public struct Project: Codable, Sendable {
     public let id: Int

--- a/RockyCore/Sources/RockyCore/Models/Session.swift
+++ b/RockyCore/Sources/RockyCore/Models/Session.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SQLiteNIO
 
 public struct Session: Codable, Sendable {
     public let id: Int
@@ -26,14 +25,5 @@ public struct Session: Codable, Sendable {
     public func duration(at now: Date = Date()) -> TimeInterval {
         let end = endTime ?? now
         return end.timeIntervalSince(startTime)
-    }
-
-    public func toSQLiteBinds() -> [SQLiteData] {
-        var binds: [SQLiteData] = [
-            .integer(projectId),
-            startTime.sqliteBind
-        ]
-        binds.append(endTime?.sqliteBind ?? .null)
-        return binds
     }
 }

--- a/RockyCore/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public final class MockProjectRepository: ProjectRepository, @unchecked Sendable {
+    private var projects: [Project] = []
+    private var nextId = 1
+
+    public init() {}
+
+    public func findOrCreate(name: String) async throws -> Project {
+        if let existing = try await getByName(name) {
+            return existing
+        }
+        let project = Project(id: nextId, parentId: nil, name: name, createdAt: Date().addingTimeInterval(Double(nextId)))
+        nextId += 1
+        projects.append(project)
+        return project
+    }
+
+    public func getById(_ id: Int) async throws -> Project? {
+        projects.first { $0.id == id }
+    }
+
+    public func getByName(_ name: String) async throws -> Project? {
+        projects.first { $0.name.lowercased() == name.lowercased() }
+    }
+
+    public func list() async throws -> [Project] {
+        projects.sorted { $0.createdAt < $1.createdAt }
+    }
+}

--- a/RockyCore/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+public final class MockSessionRepository: SessionRepository, @unchecked Sendable {
+    private var sessions: [Session] = []
+    private var nextId = 1
+    private let projectRepository: ProjectRepository
+
+    public init(projectRepository: ProjectRepository) {
+        self.projectRepository = projectRepository
+    }
+
+    public func start(projectId: Int) async throws {
+        let session = Session(id: nextId, projectId: projectId, startTime: Date(), endTime: nil)
+        nextId += 1
+        sessions.append(session)
+    }
+
+    public func hasRunningSession(projectId: Int) async throws -> Bool {
+        sessions.contains { $0.projectId == projectId && $0.isRunning }
+    }
+
+    public func stop(projectId: Int) async throws -> Session {
+        guard let index = sessions.firstIndex(where: { $0.projectId == projectId && $0.isRunning }) else {
+            throw RockyCoreError.noRunningTimers
+        }
+        let stopped = Session(
+            id: sessions[index].id,
+            projectId: sessions[index].projectId,
+            startTime: sessions[index].startTime,
+            endTime: Date()
+        )
+        sessions[index] = stopped
+        return stopped
+    }
+
+    public func stopAll() async throws -> [Session] {
+        var stopped: [Session] = []
+        for (index, session) in sessions.enumerated() where session.isRunning {
+            let s = Session(
+                id: session.id,
+                projectId: session.projectId,
+                startTime: session.startTime,
+                endTime: Date()
+            )
+            sessions[index] = s
+            stopped.append(s)
+        }
+        return stopped
+    }
+
+    public func getRunning() async throws -> [Session] {
+        sessions.filter { $0.isRunning }.sorted { $0.startTime < $1.startTime }
+    }
+
+    public func getRunningWithProjects() async throws -> [(Session, Project)] {
+        var results: [(Session, Project)] = []
+        for session in sessions where session.isRunning {
+            if let project = try await projectRepository.getById(session.projectId) {
+                results.append((session, project))
+            }
+        }
+        return results.sorted { $0.0.startTime < $1.0.startTime }
+    }
+
+    public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
+        let session = Session(id: nextId, projectId: projectId, startTime: startTime, endTime: endTime)
+        nextId += 1
+        sessions.append(session)
+    }
+
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
+        var results: [(Session, Project)] = []
+        for session in sessions {
+            if let projectId, session.projectId != projectId { continue }
+
+            let endTime = session.endTime ?? Date()
+            let overlaps = session.startTime < to && endTime > from
+            if overlaps {
+                if let project = try await projectRepository.getById(session.projectId) {
+                    results.append((session, project))
+                }
+            }
+        }
+        return results.sorted { $0.0.startTime < $1.0.startTime }
+    }
+}

--- a/RockyCore/Sources/RockyCore/Repositories/ProjectRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/ProjectRepository.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public protocol ProjectRepository: Sendable {
+    func findOrCreate(name: String) async throws -> Project
+    func getById(_ id: Int) async throws -> Project?
+    func getByName(_ name: String) async throws -> Project?
+    func list() async throws -> [Project]
+}

--- a/RockyCore/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SQLiteNIO
+
+public struct SQLiteProjectRepository: ProjectRepository, Sendable {
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    public func findOrCreate(name: String) async throws -> Project {
+        if let existing = try await getByName(name) {
+            return existing
+        }
+        try await db.execute(
+            "INSERT INTO projects (name) VALUES (?)",
+            [.text(name)]
+        )
+        let id = try await db.lastAutoincrementID()
+        let rows = try await db.query(
+            "SELECT * FROM projects WHERE id = ?",
+            [.integer(id)]
+        )
+        return try rows[0].decode(Project.self)
+    }
+
+    public func getById(_ id: Int) async throws -> Project? {
+        let rows = try await db.query(
+            "SELECT * FROM projects WHERE id = ?",
+            [.integer(id)]
+        )
+        guard let row = rows.first else { return nil }
+        return try row.decode(Project.self)
+    }
+
+    public func getByName(_ name: String) async throws -> Project? {
+        let rows = try await db.query(
+            "SELECT * FROM projects WHERE name = ? COLLATE NOCASE",
+            [.text(name)]
+        )
+        guard let row = rows.first else { return nil }
+        return try row.decode(Project.self)
+    }
+
+    public func list() async throws -> [Project] {
+        let rows = try await db.query(
+            "SELECT * FROM projects ORDER BY created_at ASC"
+        )
+        return try rows.map { try $0.decode(Project.self) }
+    }
+}

--- a/RockyCore/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SQLiteNIO
+
+public struct SQLiteSessionRepository: SessionRepository, Sendable {
+    private let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    public func start(projectId: Int) async throws {
+        try await db.execute(
+            "INSERT INTO sessions (project_id) VALUES (?)",
+            [.integer(projectId)]
+        )
+    }
+
+    public func hasRunningSession(projectId: Int) async throws -> Bool {
+        let rows = try await db.query(
+            "SELECT id FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
+            [.integer(projectId)]
+        )
+        return !rows.isEmpty
+    }
+
+    public func stop(projectId: Int) async throws -> Session {
+        let rows = try await db.query(
+            "SELECT * FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
+            [.integer(projectId)]
+        )
+        guard let row = rows.first else {
+            throw RockyCoreError.noRunningTimers
+        }
+        let session = try row.decode(Session.self)
+        try await db.execute(
+            "UPDATE sessions SET end_time = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+            [.integer(session.id)]
+        )
+        let updated = try await db.query(
+            "SELECT * FROM sessions WHERE id = ?",
+            [.integer(session.id)]
+        )
+        return try updated[0].decode(Session.self)
+    }
+
+    public func stopAll() async throws -> [Session] {
+        let running = try await getRunning()
+        var stopped: [Session] = []
+        for session in running {
+            try await db.execute(
+                "UPDATE sessions SET end_time = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+                [.integer(session.id)]
+            )
+            let updated = try await db.query(
+                "SELECT * FROM sessions WHERE id = ?",
+                [.integer(session.id)]
+            )
+            stopped.append(try updated[0].decode(Session.self))
+        }
+        return stopped
+    }
+
+    public func getRunning() async throws -> [Session] {
+        let rows = try await db.query(
+            "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC"
+        )
+        return try rows.map { try $0.decode(Session.self) }
+    }
+
+    public func getRunningWithProjects() async throws -> [(Session, Project)] {
+        let rows = try await db.query("""
+            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
+            FROM sessions s
+            JOIN projects p ON s.project_id = p.id
+            WHERE s.end_time IS NULL
+            ORDER BY s.start_time ASC
+            """)
+        return try rows.map { row in
+            let session = try row.decode(Session.self)
+            let project = try row.decode(Project.self, prefix: "p_")
+            return (session, project)
+        }
+    }
+
+    public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
+        var binds: [SQLiteData] = [
+            .integer(projectId),
+            startTime.sqliteBind
+        ]
+        binds.append(endTime?.sqliteBind ?? .null)
+        try await db.execute(
+            "INSERT INTO sessions (project_id, start_time, end_time) VALUES (?, ?, ?)",
+            binds
+        )
+    }
+
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
+        var sql = """
+            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
+            FROM sessions s
+            JOIN projects p ON s.project_id = p.id
+            WHERE (s.start_time < ? AND (s.end_time > ? OR s.end_time IS NULL))
+            """
+        var binds: [SQLiteData] = [to.sqliteBind, from.sqliteBind]
+
+        if let projectId {
+            sql += " AND s.project_id = ?"
+            binds.append(.integer(projectId))
+        }
+        sql += " ORDER BY s.start_time ASC"
+
+        let rows = try await db.query(sql, binds)
+        return try rows.map { row in
+            let session = try row.decode(Session.self)
+            let project = try row.decode(Project.self, prefix: "p_")
+            return (session, project)
+        }
+    }
+}

--- a/RockyCore/Sources/RockyCore/Repositories/SessionRepository.swift
+++ b/RockyCore/Sources/RockyCore/Repositories/SessionRepository.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol SessionRepository: Sendable {
+    func start(projectId: Int) async throws
+    func hasRunningSession(projectId: Int) async throws -> Bool
+    func stop(projectId: Int) async throws -> Session
+    func stopAll() async throws -> [Session]
+    func getRunning() async throws -> [Session]
+    func getRunningWithProjects() async throws -> [(Session, Project)]
+    func insert(projectId: Int, startTime: Date, endTime: Date?) async throws
+    func getSessions(from: Date, to: Date, projectId: Int?) async throws -> [(Session, Project)]
+}

--- a/RockyCore/Sources/RockyCore/Services/ProjectService.swift
+++ b/RockyCore/Sources/RockyCore/Services/ProjectService.swift
@@ -1,51 +1,25 @@
 import Foundation
-import SQLiteNIO
 
 public struct ProjectService: Sendable {
-    private let db: Database
+    private let repository: any ProjectRepository
 
-    public init(db: Database) {
-        self.db = db
+    public init(repository: any ProjectRepository) {
+        self.repository = repository
     }
 
     public func findOrCreate(name: String) async throws -> Project {
-        if let existing = try await getByName(name) {
-            return existing
-        }
-        try await db.execute(
-            "INSERT INTO projects (name) VALUES (?)",
-            [.text(name)]
-        )
-        let id = try await db.lastAutoincrementID()
-        let rows = try await db.query(
-            "SELECT * FROM projects WHERE id = ?",
-            [.integer(id)]
-        )
-        return try rows[0].decode(Project.self)
+        try await repository.findOrCreate(name: name)
     }
 
     public func getById(_ id: Int) async throws -> Project? {
-        let rows = try await db.query(
-            "SELECT * FROM projects WHERE id = ?",
-            [.integer(id)]
-        )
-        guard let row = rows.first else { return nil }
-        return try row.decode(Project.self)
+        try await repository.getById(id)
     }
 
     public func getByName(_ name: String) async throws -> Project? {
-        let rows = try await db.query(
-            "SELECT * FROM projects WHERE name = ? COLLATE NOCASE",
-            [.text(name)]
-        )
-        guard let row = rows.first else { return nil }
-        return try row.decode(Project.self)
+        try await repository.getByName(name)
     }
 
     public func list() async throws -> [Project] {
-        let rows = try await db.query(
-            "SELECT * FROM projects ORDER BY created_at ASC"
-        )
-        return try rows.map { try $0.decode(Project.self) }
+        try await repository.list()
     }
 }

--- a/RockyCore/Sources/RockyCore/Services/ReportService.swift
+++ b/RockyCore/Sources/RockyCore/Services/ReportService.swift
@@ -1,50 +1,43 @@
 import Foundation
-import SQLiteNIO
 
 public struct ReportService: Sendable {
-    private let db: Database
+    private let sessionRepository: any SessionRepository
+    private let projectRepository: any ProjectRepository
 
-    public init(db: Database) {
-        self.db = db
+    public init(sessionRepository: any SessionRepository, projectRepository: any ProjectRepository) {
+        self.sessionRepository = sessionRepository
+        self.projectRepository = projectRepository
     }
 
     // MARK: - Status (no flags)
 
     public func allProjectsWithStatus() async throws -> [ProjectStatus] {
-        let rows = try await db.query("""
-            SELECT p.*,
-                   s.id AS s_id, s.project_id AS s_project_id, s.start_time AS s_start_time, s.end_time AS s_end_time,
-                   (SELECT MAX(s2.end_time) FROM sessions s2 WHERE s2.project_id = p.id) AS last_active
-            FROM projects p
-            LEFT JOIN sessions s ON s.project_id = p.id AND s.end_time IS NULL
-            ORDER BY
-                CASE WHEN s.id IS NOT NULL THEN 0 ELSE 1 END,
-                s.start_time ASC,
-                last_active DESC,
-                p.created_at DESC
-            """)
+        let projects = try await projectRepository.list()
+        let runningSessions = try await sessionRepository.getRunningWithProjects()
 
-        var seen = Set<Int>()
-        var results: [ProjectStatus] = []
-        for row in rows {
-            let project = try row.decode(Project.self)
-            if seen.contains(project.id) { continue }
-            seen.insert(project.id)
+        let runningByProjectId = Dictionary(
+            runningSessions.map { ($0.0.projectId, $0.0) },
+            uniquingKeysWith: { first, _ in first }
+        )
 
-            var runningSession: Session? = nil
-            if row.column("s_id")?.integer != nil {
-                runningSession = try row.decode(Session.self, prefix: "s_")
+        var running: [ProjectStatus] = []
+        var idle: [ProjectStatus] = []
+
+        for project in projects {
+            if let session = runningByProjectId[project.id] {
+                running.append(ProjectStatus(project: project, runningSession: session))
+            } else {
+                idle.append(ProjectStatus(project: project, runningSession: nil))
             }
-            results.append(ProjectStatus(project: project, runningSession: runningSession))
         }
-        return results
+
+        return running + idle
     }
 
     // MARK: - Time range reports
 
     public func totals(from: Date, to: Date, projectId: Int? = nil) async throws -> ProjectTotals {
-        let sessionService = SessionService(db: db)
-        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
         let now = Date()
 
         var projectDurations: [String: TimeInterval] = [:]
@@ -92,8 +85,7 @@ public struct ReportService: Sendable {
     }
 
     private func grouped(from: Date, to: Date, projectId: Int? = nil, grouping: Grouping) async throws -> GroupedReport {
-        let sessionService = SessionService(db: db)
-        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
         let now = Date()
         let calendar = Calendar.current
 
@@ -139,8 +131,7 @@ public struct ReportService: Sendable {
     }
 
     public func verboseSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [VerboseSessionRow] {
-        let sessionService = SessionService(db: db)
-        let sessions = try await sessionService.getSessions(from: from, to: to, projectId: projectId)
+        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
 
         return sessions.map { session, project in
             VerboseSessionRow(

--- a/RockyCore/Sources/RockyCore/Services/SessionService.swift
+++ b/RockyCore/Sources/RockyCore/Services/SessionService.swift
@@ -1,115 +1,41 @@
 import Foundation
-import SQLiteNIO
 
 public struct SessionService: Sendable {
-    private let db: Database
+    private let repository: any SessionRepository
 
-    public init(db: Database) {
-        self.db = db
+    public init(repository: any SessionRepository) {
+        self.repository = repository
     }
 
     public func start(projectId: Int) async throws {
-        try await db.execute(
-            "INSERT INTO sessions (project_id) VALUES (?)",
-            [.integer(projectId)]
-        )
+        try await repository.start(projectId: projectId)
     }
 
     public func hasRunningSession(projectId: Int) async throws -> Bool {
-        let rows = try await db.query(
-            "SELECT id FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
-            [.integer(projectId)]
-        )
-        return !rows.isEmpty
+        try await repository.hasRunningSession(projectId: projectId)
     }
 
     public func stop(projectId: Int) async throws -> Session {
-        let rows = try await db.query(
-            "SELECT * FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
-            [.integer(projectId)]
-        )
-        guard let row = rows.first else {
-            throw RockyCoreError.noRunningTimers
-        }
-        let session = try row.decode(Session.self)
-        try await db.execute(
-            "UPDATE sessions SET end_time = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
-            [.integer(session.id)]
-        )
-        let updated = try await db.query(
-            "SELECT * FROM sessions WHERE id = ?",
-            [.integer(session.id)]
-        )
-        return try updated[0].decode(Session.self)
+        try await repository.stop(projectId: projectId)
     }
 
     public func stopAll() async throws -> [Session] {
-        let running = try await getRunning()
-        var stopped: [Session] = []
-        for session in running {
-            try await db.execute(
-                "UPDATE sessions SET end_time = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
-                [.integer(session.id)]
-            )
-            let updated = try await db.query(
-                "SELECT * FROM sessions WHERE id = ?",
-                [.integer(session.id)]
-            )
-            stopped.append(try updated[0].decode(Session.self))
-        }
-        return stopped
+        try await repository.stopAll()
     }
 
     public func getRunning() async throws -> [Session] {
-        let rows = try await db.query(
-            "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC"
-        )
-        return try rows.map { try $0.decode(Session.self) }
+        try await repository.getRunning()
     }
 
     public func getRunningWithProjects() async throws -> [(Session, Project)] {
-        let rows = try await db.query("""
-            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
-            FROM sessions s
-            JOIN projects p ON s.project_id = p.id
-            WHERE s.end_time IS NULL
-            ORDER BY s.start_time ASC
-            """)
-        return try rows.map { row in
-            let session = try row.decode(Session.self)
-            let project = try row.decode(Project.self, prefix: "p_")
-            return (session, project)
-        }
+        try await repository.getRunningWithProjects()
     }
 
     public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
-        let session = Session(id: 0, projectId: projectId, startTime: startTime, endTime: endTime)
-        try await db.execute(
-            "INSERT INTO sessions (project_id, start_time, end_time) VALUES (?, ?, ?)",
-            session.toSQLiteBinds()
-        )
+        try await repository.insert(projectId: projectId, startTime: startTime, endTime: endTime)
     }
 
     public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
-        var sql = """
-            SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id, p.name AS p_name, p.created_at AS p_created_at
-            FROM sessions s
-            JOIN projects p ON s.project_id = p.id
-            WHERE (s.start_time < ? AND (s.end_time > ? OR s.end_time IS NULL))
-            """
-        var binds: [SQLiteData] = [to.sqliteBind, from.sqliteBind]
-
-        if let projectId {
-            sql += " AND s.project_id = ?"
-            binds.append(.integer(projectId))
-        }
-        sql += " ORDER BY s.start_time ASC"
-
-        let rows = try await db.query(sql, binds)
-        return try rows.map { row in
-            let session = try row.decode(Session.self)
-            let project = try row.decode(Project.self, prefix: "p_")
-            return (session, project)
-        }
+        try await repository.getSessions(from: from, to: to, projectId: projectId)
     }
 }

--- a/RockyCore/Tests/RockyCoreTests/RockyCoreTests.swift
+++ b/RockyCore/Tests/RockyCoreTests/RockyCoreTests.swift
@@ -2,27 +2,7 @@ import Testing
 import Foundation
 @testable import RockyCore
 
-// MARK: - Shared test database
-
-actor TestDatabase {
-    static let shared = TestDatabase()
-    private var db: Database?
-
-    func get() async throws -> Database {
-        if let db { return db }
-        let db = try await Database.open(at: ":memory:")
-        self.db = db
-        return db
-    }
-
-    func reset() async throws {
-        let db = try await get()
-        try await db.execute("DELETE FROM sessions")
-        try await db.execute("DELETE FROM projects")
-    }
-}
-
-// MARK: - Session Model (no database needed)
+// MARK: - Session Model (pure logic, no dependencies)
 
 @Suite("Session Model")
 struct SessionModelTests {
@@ -44,12 +24,624 @@ struct SessionModelTests {
     }
 }
 
-// MARK: - Database tests (single shared connection, serialized)
+// MARK: - Mock Project Repository Tests
 
-@Suite("Database Tests", .serialized)
-struct DatabaseTests {
+@Suite("MockProjectRepository")
+struct MockProjectRepositoryTests {
+    @Test("findOrCreate creates a new project")
+    func createProject() async throws {
+        let repo = MockProjectRepository()
+        let project = try await repo.findOrCreate(name: "acme-corp")
+        #expect(project.name == "acme-corp")
+        #expect(project.id > 0)
+        #expect(project.parentId == nil)
+    }
 
-    // MARK: - Migrations
+    @Test("findOrCreate returns existing project on duplicate name")
+    func findExisting() async throws {
+        let repo = MockProjectRepository()
+        let first = try await repo.findOrCreate(name: "acme-corp")
+        let second = try await repo.findOrCreate(name: "acme-corp")
+        #expect(first.id == second.id)
+    }
+
+    @Test("getByName is case-insensitive")
+    func caseInsensitive() async throws {
+        let repo = MockProjectRepository()
+        _ = try await repo.findOrCreate(name: "Acme-Corp")
+        let found = try await repo.getByName("acme-corp")
+        #expect(found != nil)
+        #expect(found?.name == "Acme-Corp")
+    }
+
+    @Test("getByName returns nil for unknown project")
+    func unknownProject() async throws {
+        let repo = MockProjectRepository()
+        let found = try await repo.getByName("nonexistent")
+        #expect(found == nil)
+    }
+
+    @Test("getById returns correct project")
+    func getById() async throws {
+        let repo = MockProjectRepository()
+        let created = try await repo.findOrCreate(name: "test-project")
+        let found = try await repo.getById(created.id)
+        #expect(found != nil)
+        #expect(found?.name == "test-project")
+    }
+
+    @Test("getById returns nil for unknown id")
+    func getByIdUnknown() async throws {
+        let repo = MockProjectRepository()
+        let found = try await repo.getById(999)
+        #expect(found == nil)
+    }
+
+    @Test("list returns all projects")
+    func listProjects() async throws {
+        let repo = MockProjectRepository()
+        _ = try await repo.findOrCreate(name: "alpha")
+        _ = try await repo.findOrCreate(name: "beta")
+        _ = try await repo.findOrCreate(name: "gamma")
+        let projects = try await repo.list()
+        #expect(projects.count == 3)
+    }
+
+    @Test("findOrCreate deduplicates case-insensitively")
+    func findOrCreateCaseInsensitive() async throws {
+        let repo = MockProjectRepository()
+        let first = try await repo.findOrCreate(name: "acme-corp")
+        let second = try await repo.findOrCreate(name: "ACME-CORP")
+        #expect(first.id == second.id)
+        #expect(second.name == "acme-corp")
+        let projects = try await repo.list()
+        #expect(projects.count == 1)
+    }
+
+    @Test("list returns projects in creation order")
+    func listOrder() async throws {
+        let repo = MockProjectRepository()
+        _ = try await repo.findOrCreate(name: "charlie")
+        _ = try await repo.findOrCreate(name: "alpha")
+        _ = try await repo.findOrCreate(name: "bravo")
+        let projects = try await repo.list()
+        #expect(projects[0].name == "charlie")
+        #expect(projects[1].name == "alpha")
+        #expect(projects[2].name == "bravo")
+    }
+}
+
+// MARK: - Mock Session Repository Tests
+
+@Suite("MockSessionRepository")
+struct MockSessionRepositoryTests {
+    @Test("start creates a running session")
+    func startSession() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        try await sessionRepo.start(projectId: project.id)
+        let running = try await sessionRepo.getRunning()
+        #expect(running.count == 1)
+        #expect(running[0].projectId == project.id)
+        #expect(running[0].isRunning)
+    }
+
+    @Test("hasRunningSession returns false when nothing running")
+    func hasRunningFalse() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        #expect(try await sessionRepo.hasRunningSession(projectId: project.id) == false)
+    }
+
+    @Test("hasRunningSession returns true after start")
+    func hasRunningTrue() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        try await sessionRepo.start(projectId: project.id)
+        #expect(try await sessionRepo.hasRunningSession(projectId: project.id) == true)
+    }
+
+    @Test("stop sets end_time on session")
+    func stopSession() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        try await sessionRepo.start(projectId: project.id)
+        let stopped = try await sessionRepo.stop(projectId: project.id)
+        #expect(stopped.endTime != nil)
+        #expect(!stopped.isRunning)
+        let running = try await sessionRepo.getRunning()
+        #expect(running.isEmpty)
+    }
+
+    @Test("stop throws when no running session")
+    func stopNoRunning() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        await #expect(throws: RockyCoreError.self) {
+            try await sessionRepo.stop(projectId: project.id)
+        }
+    }
+
+    @Test("stopAll stops all running sessions")
+    func stopAll() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let p1 = try await projectRepo.findOrCreate(name: "project-1")
+        let p2 = try await projectRepo.findOrCreate(name: "project-2")
+        try await sessionRepo.start(projectId: p1.id)
+        try await sessionRepo.start(projectId: p2.id)
+        let stopped = try await sessionRepo.stopAll()
+        #expect(stopped.count == 2)
+        #expect(stopped.allSatisfy { !$0.isRunning })
+        let running = try await sessionRepo.getRunning()
+        #expect(running.isEmpty)
+    }
+
+    @Test("stopAll returns empty array when nothing running")
+    func stopAllEmpty() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let stopped = try await sessionRepo.stopAll()
+        #expect(stopped.isEmpty)
+    }
+
+    @Test("concurrent timers on different projects")
+    func concurrentTimers() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let p1 = try await projectRepo.findOrCreate(name: "project-1")
+        let p2 = try await projectRepo.findOrCreate(name: "project-2")
+        try await sessionRepo.start(projectId: p1.id)
+        try await sessionRepo.start(projectId: p2.id)
+        let running = try await sessionRepo.getRunning()
+        #expect(running.count == 2)
+    }
+
+    @Test("stop one timer leaves other running")
+    func stopOneOfTwo() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let p1 = try await projectRepo.findOrCreate(name: "project-1")
+        let p2 = try await projectRepo.findOrCreate(name: "project-2")
+        try await sessionRepo.start(projectId: p1.id)
+        try await sessionRepo.start(projectId: p2.id)
+        _ = try await sessionRepo.stop(projectId: p1.id)
+        let running = try await sessionRepo.getRunning()
+        #expect(running.count == 1)
+        #expect(running[0].projectId == p2.id)
+    }
+
+    @Test("getRunningWithProjects returns session and project data")
+    func runningWithProjects() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let project = try await projectRepo.findOrCreate(name: "acme-corp")
+        try await sessionRepo.start(projectId: project.id)
+        let running = try await sessionRepo.getRunningWithProjects()
+        #expect(running.count == 1)
+        #expect(running[0].0.projectId == project.id)
+        #expect(running[0].1.name == "acme-corp")
+    }
+
+    @Test("insert creates session with explicit start/end times")
+    func insertSession() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+        let start = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
+        let end = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
+        try await sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let results = try await sessionRepo.getSessions(from: from, to: to)
+        #expect(results.count == 1)
+        #expect(results[0].0.startTime == start)
+        #expect(results[0].0.endTime == end)
+    }
+
+    @Test("getSessions returns sessions overlapping date range")
+    func getSessionsDateRange() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        // Fully inside range
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
+        // Fully outside range (day before)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 11))!)
+        // Spanning into range
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 23))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 1))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let results = try await sessionRepo.getSessions(from: from, to: to)
+
+        #expect(results.count == 2)
+    }
+
+    @Test("getSessions excludes sessions outside the range")
+    func getSessionsOutsideRange() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 11))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let results = try await sessionRepo.getSessions(from: from, to: to)
+
+        #expect(results.isEmpty)
+    }
+
+    @Test("stopAll only affects running sessions")
+    func stopAllLeavesStoppedAlone() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let p1 = try await projectRepo.findOrCreate(name: "already-stopped")
+        let p2 = try await projectRepo.findOrCreate(name: "still-running")
+        try await sessionRepo.start(projectId: p1.id)
+        _ = try await sessionRepo.stop(projectId: p1.id)
+        try await sessionRepo.start(projectId: p2.id)
+        let stopped = try await sessionRepo.stopAll()
+        #expect(stopped.count == 1)
+        #expect(stopped[0].projectId == p2.id)
+    }
+
+    @Test("getSessions filters by projectId")
+    func getSessionsFilterByProject() async throws {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let cal = Calendar.current
+        let p1 = try await projectRepo.findOrCreate(name: "included")
+        let p2 = try await projectRepo.findOrCreate(name: "excluded")
+
+        try await sessionRepo.insert(projectId: p1.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
+        try await sessionRepo.insert(projectId: p2.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let results = try await sessionRepo.getSessions(from: from, to: to, projectId: p1.id)
+
+        #expect(results.count == 1)
+        #expect(results[0].1.name == "included")
+    }
+}
+
+// MARK: - ReportService Tests (with mock repositories)
+
+@Suite("ReportService")
+struct ReportServiceTests {
+    private func makeServices() -> (MockProjectRepository, MockSessionRepository, ReportService) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let reportService = ReportService(sessionRepository: sessionRepo, projectRepository: projectRepo)
+        return (projectRepo, sessionRepo, reportService)
+    }
+
+    @Test("allProjectsWithStatus returns empty for no projects")
+    func statusEmpty() async throws {
+        let (_, _, reportService) = makeServices()
+        let statuses = try await reportService.allProjectsWithStatus()
+        #expect(statuses.isEmpty)
+    }
+
+    @Test("allProjectsWithStatus shows idle projects with no sessions")
+    func statusNoSessions() async throws {
+        let (projectRepo, _, reportService) = makeServices()
+        _ = try await projectRepo.findOrCreate(name: "idle-project")
+        let statuses = try await reportService.allProjectsWithStatus()
+        #expect(statuses.count == 1)
+        #expect(!statuses[0].isRunning)
+        #expect(statuses[0].runningSession == nil)
+    }
+
+    @Test("allProjectsWithStatus shows running projects first")
+    func statusOrder() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let p1 = try await projectRepo.findOrCreate(name: "inactive")
+        let p2 = try await projectRepo.findOrCreate(name: "active")
+        try await sessionRepo.start(projectId: p1.id)
+        _ = try await sessionRepo.stop(projectId: p1.id)
+        try await sessionRepo.start(projectId: p2.id)
+
+        let statuses = try await reportService.allProjectsWithStatus()
+        #expect(statuses.count == 2)
+        #expect(statuses[0].project.name == "active")
+        #expect(statuses[0].isRunning)
+        #expect(statuses[1].project.name == "inactive")
+        #expect(!statuses[1].isRunning)
+    }
+
+    @Test("totals calculates project durations in range")
+    func totals() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+
+        let result = try await reportService.totals(from: from, to: to)
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].projectName == "test")
+        #expect(abs(result.entries[0].duration - 3600) < 1)
+    }
+
+    @Test("totals filters by project")
+    func totalsFiltered() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let p1 = try await projectRepo.findOrCreate(name: "included")
+        let p2 = try await projectRepo.findOrCreate(name: "excluded")
+
+        try await sessionRepo.insert(projectId: p1.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
+        try await sessionRepo.insert(projectId: p2.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+
+        let result = try await reportService.totals(from: from, to: to, projectId: p1.id)
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].projectName == "included")
+    }
+
+    @Test("totals sums multiple sessions for same project")
+    func totalsSumMultiple() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+
+        let result = try await reportService.totals(from: from, to: to)
+        #expect(result.entries.count == 1)
+        #expect(abs(result.entries[0].duration - 7200) < 1)
+    }
+
+    @Test("totals returns empty entries for range with no sessions")
+    func totalsEmpty() async throws {
+        let (_, _, reportService) = makeServices()
+        let cal = Calendar.current
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let result = try await reportService.totals(from: from, to: to)
+        #expect(result.entries.isEmpty)
+        #expect(result.total == 0)
+    }
+
+    @Test("totals includes running session duration up to range end")
+    func totalsRunningSession() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "running")
+
+        // Insert a running session (no endTime) that started 2 hours ago
+        let startTime = Date().addingTimeInterval(-7200)
+        try await sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: nil)
+
+        let from = cal.startOfDay(for: Date())
+        let to = cal.date(byAdding: .day, value: 1, to: from)!
+
+        let result = try await reportService.totals(from: from, to: to)
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].isRunning)
+        #expect(result.entries[0].duration > 0)
+    }
+
+    @Test("totals clamps sessions that partially overlap the range")
+    func partialOverlap() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 22))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 2))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+
+        let result = try await reportService.totals(from: from, to: to)
+        #expect(result.entries.count == 1)
+        #expect(abs(result.entries[0].duration - 7200) < 1)
+    }
+
+    @Test("groupedByDay distributes sessions across correct days")
+    func groupedByDay() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 12))!)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 9))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 10))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 8))!
+
+        let report = try await reportService.groupedByDay(from: from, to: to)
+        #expect(report.columns.count == 6)
+        #expect(report.rows.count == 1)
+        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
+        #expect(abs((report.rows[0].columnDurations[2] ?? 0) - 3600) < 1)
+        #expect((report.rows[0].columnDurations[1] ?? 0) < 1)
+    }
+
+    @Test("session spanning midnight splits across days")
+    func sessionSpanningMidnight() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "late-night")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 23))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 3, hour: 1))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 4))!
+
+        let report = try await reportService.groupedByDay(from: from, to: to)
+        #expect(report.columns.count == 2)
+        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 3600) < 1)
+        #expect(abs((report.rows[0].columnDurations[1] ?? 0) - 3600) < 1)
+    }
+
+    @Test("groupedByWeek creates correct week columns")
+    func groupedByWeek() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 11))!)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 11))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 15))!
+
+        let report = try await reportService.groupedByWeek(from: from, to: to)
+        #expect(report.rows.count == 1)
+        #expect(report.columns.count >= 2)
+        #expect(abs(report.grandTotal - 7200) < 1)
+    }
+
+    @Test("groupedByMonth creates correct month columns")
+    func groupedByMonth() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 12))!)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 9))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 10))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 1, day: 1))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+
+        let report = try await reportService.groupedByMonth(from: from, to: to)
+        #expect(report.columns.count == 3)
+        #expect(report.rows.count == 1)
+        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
+        #expect((report.rows[0].columnDurations[1] ?? 0) < 1)
+        #expect(abs((report.rows[0].columnDurations[2] ?? 0) - 3600) < 1)
+    }
+
+    @Test("verboseSessions returns individual session rows")
+    func verboseSessions() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "test")
+
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
+        try await sessionRepo.insert(projectId: project.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+
+        let rows = try await reportService.verboseSessions(from: from, to: to)
+        #expect(rows.count == 2)
+        #expect(rows[0].projectName == "test")
+        #expect(rows[1].projectName == "test")
+        #expect(rows[0].session.endTime != nil)
+    }
+
+    @Test("multiple projects sorted by total duration, running first")
+    func multipleProjectsGrouped() async throws {
+        let (projectRepo, sessionRepo, reportService) = makeServices()
+        let cal = Calendar.current
+        let p1 = try await projectRepo.findOrCreate(name: "alpha")
+        let p2 = try await projectRepo.findOrCreate(name: "beta")
+
+        try await sessionRepo.insert(projectId: p1.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 13))!)
+        try await sessionRepo.insert(projectId: p2.id,
+            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!,
+            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 3))!
+
+        let report = try await reportService.groupedByDay(from: from, to: to)
+        #expect(report.rows.count == 2)
+        #expect(report.rows[0].projectName == "alpha")
+        #expect(report.rows[1].projectName == "beta")
+    }
+}
+
+// MARK: - SQLite Integration Tests (real database, serialized)
+
+actor TestDatabase {
+    static let shared = TestDatabase()
+    private var db: Database?
+
+    func get() async throws -> Database {
+        if let db { return db }
+        let db = try await Database.open(at: ":memory:")
+        self.db = db
+        return db
+    }
+
+    func reset() async throws {
+        let db = try await get()
+        try await db.execute("DELETE FROM sessions")
+        try await db.execute("DELETE FROM projects")
+    }
+}
+
+@Suite("SQLite Integration", .serialized)
+struct SQLiteIntegrationTests {
 
     @Test("Tables exist after migration")
     func tablesExist() async throws {
@@ -71,492 +663,89 @@ struct DatabaseTests {
         #expect(rows[0].column("version")?.integer == 1)
     }
 
-    // MARK: - ProjectService
-
-    @Test("findOrCreate creates a new project")
-    func createProject() async throws {
-        try await TestDatabase.shared.reset()
+    @Test("Migrations are idempotent")
+    func migrationsIdempotent() async throws {
         let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        let project = try await service.findOrCreate(name: "acme-corp")
-        #expect(project.name == "acme-corp")
-        #expect(project.id > 0)
-        #expect(project.parentId == nil)
+        try await Migrations.run(on: db)
+        let rows = try await db.query("SELECT version FROM migrations")
+        #expect(rows.count == 1)
     }
 
-    @Test("findOrCreate returns existing project")
-    func findExisting() async throws {
+    @Test("SQLiteProjectRepository round-trips project data")
+    func projectRoundTrip() async throws {
         try await TestDatabase.shared.reset()
         let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        let first = try await service.findOrCreate(name: "acme-corp")
-        let second = try await service.findOrCreate(name: "acme-corp")
-        #expect(first.id == second.id)
-    }
-
-    @Test("getByName is case-insensitive")
-    func caseInsensitive() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        _ = try await service.findOrCreate(name: "Acme-Corp")
-        let found = try await service.getByName("acme-corp")
+        let repo = SQLiteProjectRepository(db: db)
+        let created = try await repo.findOrCreate(name: "round-trip-test")
+        let found = try await repo.getById(created.id)
         #expect(found != nil)
-        #expect(found?.name == "Acme-Corp")
+        #expect(found?.name == "round-trip-test")
+        #expect(found?.id == created.id)
     }
 
-    @Test("getByName returns nil for unknown project")
-    func unknownProject() async throws {
+    @Test("SQLiteSessionRepository round-trips session data")
+    func sessionRoundTrip() async throws {
         try await TestDatabase.shared.reset()
         let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        let found = try await service.getByName("nonexistent")
-        #expect(found == nil)
+        let projectRepo = SQLiteProjectRepository(db: db)
+        let sessionRepo = SQLiteSessionRepository(db: db)
+        let cal = Calendar.current
+        let project = try await projectRepo.findOrCreate(name: "round-trip-test")
+
+        let startTime = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
+        let endTime = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
+        try await sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: endTime)
+
+        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
+        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
+        let results = try await sessionRepo.getSessions(from: from, to: to)
+
+        #expect(results.count == 1)
+        #expect(abs(results[0].0.startTime.timeIntervalSince(startTime)) < 1)
+        #expect(abs(results[0].0.endTime!.timeIntervalSince(endTime)) < 1)
     }
 
-    @Test("list returns all projects")
-    func listProjects() async throws {
+    @Test("SQLite start and stop round-trip")
+    func startStopRoundTrip() async throws {
         try await TestDatabase.shared.reset()
         let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        _ = try await service.findOrCreate(name: "alpha")
-        _ = try await service.findOrCreate(name: "beta")
-        _ = try await service.findOrCreate(name: "gamma")
-        let projects = try await service.list()
-        #expect(projects.count == 3)
-    }
+        let projectRepo = SQLiteProjectRepository(db: db)
+        let sessionRepo = SQLiteSessionRepository(db: db)
+        let project = try await projectRepo.findOrCreate(name: "start-stop-test")
+        try await sessionRepo.start(projectId: project.id)
 
-    @Test("getById returns correct project")
-    func getById() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let service = ProjectService(db: db)
-        let created = try await service.findOrCreate(name: "test-project")
-        let found = try await service.getById(created.id)
-        #expect(found != nil)
-        #expect(found?.name == "test-project")
-    }
-
-    // MARK: - SessionService
-
-    @Test("start creates a running session")
-    func startSession() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let project = try await projects.findOrCreate(name: "acme-corp")
-        try await sessions.start(projectId: project.id)
-        let running = try await sessions.getRunning()
+        let running = try await sessionRepo.getRunning()
         #expect(running.count == 1)
-        #expect(running[0].projectId == project.id)
         #expect(running[0].isRunning)
-    }
 
-    @Test("hasRunningSession detects active timer")
-    func hasRunning() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let project = try await projects.findOrCreate(name: "acme-corp")
-        #expect(try await sessions.hasRunningSession(projectId: project.id) == false)
-        try await sessions.start(projectId: project.id)
-        #expect(try await sessions.hasRunningSession(projectId: project.id) == true)
-    }
-
-    @Test("stop sets end_time on session")
-    func stopSession() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let project = try await projects.findOrCreate(name: "acme-corp")
-        try await sessions.start(projectId: project.id)
-        let stopped = try await sessions.stop(projectId: project.id)
-        #expect(stopped.endTime != nil)
+        let stopped = try await sessionRepo.stop(projectId: project.id)
         #expect(!stopped.isRunning)
-        let running = try await sessions.getRunning()
-        #expect(running.isEmpty)
+        #expect(stopped.endTime != nil)
+
+        let afterStop = try await sessionRepo.getRunning()
+        #expect(afterStop.isEmpty)
     }
 
-    @Test("stopAll stops all running sessions")
-    func stopAll() async throws {
+    @Test("SQLite findOrCreate deduplicates case-insensitively")
+    func findOrCreateCaseInsensitiveSQLite() async throws {
         try await TestDatabase.shared.reset()
         let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let p1 = try await projects.findOrCreate(name: "project-1")
-        let p2 = try await projects.findOrCreate(name: "project-2")
-        try await sessions.start(projectId: p1.id)
-        try await sessions.start(projectId: p2.id)
-        let stopped = try await sessions.stopAll()
-        #expect(stopped.count == 2)
-        #expect(stopped.allSatisfy { !$0.isRunning })
-        let running = try await sessions.getRunning()
-        #expect(running.isEmpty)
+        let repo = SQLiteProjectRepository(db: db)
+        let first = try await repo.findOrCreate(name: "acme-corp")
+        let second = try await repo.findOrCreate(name: "ACME-CORP")
+        #expect(first.id == second.id)
+        let projects = try await repo.list()
+        #expect(projects.count == 1)
     }
 
-    @Test("concurrent timers on different projects")
-    func concurrentTimers() async throws {
+    @Test("Case-insensitive project lookup works in SQLite")
+    func caseInsensitiveSQLite() async throws {
         try await TestDatabase.shared.reset()
         let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let p1 = try await projects.findOrCreate(name: "project-1")
-        let p2 = try await projects.findOrCreate(name: "project-2")
-        try await sessions.start(projectId: p1.id)
-        try await sessions.start(projectId: p2.id)
-        let running = try await sessions.getRunning()
-        #expect(running.count == 2)
-    }
-
-    @Test("stop one timer leaves other running")
-    func stopOneOfTwo() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let p1 = try await projects.findOrCreate(name: "project-1")
-        let p2 = try await projects.findOrCreate(name: "project-2")
-        try await sessions.start(projectId: p1.id)
-        try await sessions.start(projectId: p2.id)
-        _ = try await sessions.stop(projectId: p1.id)
-        let running = try await sessions.getRunning()
-        #expect(running.count == 1)
-        #expect(running[0].projectId == p2.id)
-    }
-
-    @Test("getRunningWithProjects returns session and project data")
-    func runningWithProjects() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let project = try await projects.findOrCreate(name: "acme-corp")
-        try await sessions.start(projectId: project.id)
-        let running = try await sessions.getRunningWithProjects()
-        #expect(running.count == 1)
-        #expect(running[0].0.projectId == project.id)
-        #expect(running[0].1.name == "acme-corp")
-    }
-
-    @Test("stop throws when no running session")
-    func stopNoRunning() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let project = try await projects.findOrCreate(name: "acme-corp")
-        await #expect(throws: RockyCoreError.self) {
-            try await sessions.stop(projectId: project.id)
-        }
-    }
-
-    @Test("stopAll with nothing running returns empty array")
-    func stopAllEmpty() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let sessions = SessionService(db: db)
-        let stopped = try await sessions.stopAll()
-        #expect(stopped.isEmpty)
-    }
-
-    @Test("getSessions returns sessions overlapping date range")
-    func getSessionsDateRange() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 11))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 23))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 1))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessions.getSessions(from: from, to: to)
-
-        #expect(results.count == 2)
-    }
-
-    // MARK: - ReportService
-
-    @Test("allProjectsWithStatus shows running projects first")
-    func statusOrder() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let p1 = try await projects.findOrCreate(name: "inactive")
-        let p2 = try await projects.findOrCreate(name: "active")
-        try await sessions.start(projectId: p1.id)
-        _ = try await sessions.stop(projectId: p1.id)
-        try await sessions.start(projectId: p2.id)
-
-        let statuses = try await reports.allProjectsWithStatus()
-        #expect(statuses.count == 2)
-        #expect(statuses[0].project.name == "active")
-        #expect(statuses[0].isRunning)
-        #expect(statuses[1].project.name == "inactive")
-        #expect(!statuses[1].isRunning)
-    }
-
-    @Test("totals calculates project durations in range")
-    func totals() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let project = try await projects.findOrCreate(name: "test")
-        try await sessions.start(projectId: project.id)
-        _ = try await sessions.stop(projectId: project.id)
-
-        let cal = Calendar.current
-        let start = cal.startOfDay(for: Date())
-        let end = cal.date(byAdding: .day, value: 1, to: start)!
-
-        let result = try await reports.totals(from: start, to: end)
-        #expect(result.entries.count == 1)
-        #expect(result.entries[0].projectName == "test")
-    }
-
-    @Test("totals filters by project")
-    func totalsFiltered() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let p1 = try await projects.findOrCreate(name: "included")
-        let p2 = try await projects.findOrCreate(name: "excluded")
-        try await sessions.start(projectId: p1.id)
-        _ = try await sessions.stop(projectId: p1.id)
-        try await sessions.start(projectId: p2.id)
-        _ = try await sessions.stop(projectId: p2.id)
-
-        let cal = Calendar.current
-        let start = cal.startOfDay(for: Date())
-        let end = cal.date(byAdding: .day, value: 1, to: start)!
-
-        let result = try await reports.totals(from: start, to: end, projectId: p1.id)
-        #expect(result.entries.count == 1)
-        #expect(result.entries[0].projectName == "included")
-    }
-
-    @Test("totals sums multiple sessions for same project")
-    func totalsSumMultiple() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-
-        let result = try await reports.totals(from: from, to: to)
-        #expect(result.entries.count == 1)
-        #expect(abs(result.entries[0].duration - 7200) < 1)
-    }
-
-    @Test("groupedByDay distributes session across correct days")
-    func groupedByDay() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 12))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 9))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 10))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 8))!
-
-        let report = try await reports.groupedByDay(from: from, to: to)
-        #expect(report.columns.count == 6)
-        #expect(report.rows.count == 1)
-        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
-        #expect(abs((report.rows[0].columnDurations[2] ?? 0) - 3600) < 1)
-        #expect((report.rows[0].columnDurations[1] ?? 0) < 1)
-    }
-
-    @Test("session spanning midnight splits across days")
-    func sessionSpanningMidnight() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "late-night")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 23))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 3, hour: 1))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 4))!
-
-        let report = try await reports.groupedByDay(from: from, to: to)
-        #expect(report.columns.count == 2)
-        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 3600) < 1)
-        #expect(abs((report.rows[0].columnDurations[1] ?? 0) - 3600) < 1)
-    }
-
-    @Test("groupedByWeek creates correct week columns")
-    func groupedByWeek() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 11))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 11))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 15))!
-
-        let report = try await reports.groupedByWeek(from: from, to: to)
-        #expect(report.rows.count == 1)
-        #expect(report.columns.count >= 2)
-        #expect(abs(report.grandTotal - 7200) < 1)
-    }
-
-    @Test("groupedByMonth creates correct month columns")
-    func groupedByMonth() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 12))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 9))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 10))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 1, day: 1))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
-
-        let report = try await reports.groupedByMonth(from: from, to: to)
-        #expect(report.columns.count == 3)
-        #expect(report.rows.count == 1)
-        #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
-        #expect((report.rows[0].columnDurations[1] ?? 0) < 1)
-        #expect(abs((report.rows[0].columnDurations[2] ?? 0) - 3600) < 1)
-    }
-
-    @Test("verboseSessions returns individual session rows")
-    func verboseSessions() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-
-        let rows = try await reports.verboseSessions(from: from, to: to)
-        #expect(rows.count == 2)
-        #expect(rows[0].projectName == "test")
-        #expect(rows[1].projectName == "test")
-        #expect(rows[0].session.endTime != nil)
-    }
-
-    @Test("session partially overlapping range is clamped")
-    func partialOverlap() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let project = try await projects.findOrCreate(name: "test")
-
-        try await sessions.insert(projectId: project.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 22))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 2))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-
-        let result = try await reports.totals(from: from, to: to)
-        #expect(result.entries.count == 1)
-        #expect(abs(result.entries[0].duration - 7200) < 1)
-    }
-
-    @Test("multiple projects in grouped report sorted by duration")
-    func multipleProjectsGrouped() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
-        let projects = ProjectService(db: db)
-        let sessions = SessionService(db: db)
-        let reports = ReportService(db: db)
-        let cal = Calendar.current
-        let p1 = try await projects.findOrCreate(name: "alpha")
-        let p2 = try await projects.findOrCreate(name: "beta")
-
-        try await sessions.insert(projectId: p1.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 13))!)
-        try await sessions.insert(projectId: p2.id,
-            startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!,
-            endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!)
-
-        let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
-        let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 3))!
-
-        let report = try await reports.groupedByDay(from: from, to: to)
-        #expect(report.rows.count == 2)
-        #expect(report.rows[0].projectName == "alpha")
-        #expect(report.rows[1].projectName == "beta")
+        let repo = SQLiteProjectRepository(db: db)
+        _ = try await repo.findOrCreate(name: "MyProject")
+        let found = try await repo.getByName("myproject")
+        #expect(found != nil)
+        #expect(found?.name == "MyProject")
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `ProjectRepository` and `SessionRepository` protocols decoupling business logic from SQLite
- `SQLiteProjectRepository` / `SQLiteSessionRepository` contain all SQL code
- `MockProjectRepository` / `MockSessionRepository` for fast, isolated unit tests
- Services (`ProjectService`, `SessionService`, `ReportService`) now accept protocols via init
- `AppContext` in RockyCLI serves as the composition root — commands no longer know about repositories
- Models (`Project`, `Session`) no longer import `SQLiteNIO`; `toSQLiteBinds()` moved to SQLite layer
- Tests rewritten: 40 mock-based tests run in parallel, 9 SQLite integration tests run serialized (49 total)

Closes #28

## Test plan

- [x] `swift build` succeeds for RockyCore and RockyCLI
- [x] `swift test` passes all 49 tests across 5 suites
- [x] Mock-based tests require no database connection
- [x] SQLite integration tests validate round-trip data integrity
- [x] No code outside `Repositories/SQLite/` imports `SQLiteNIO` (except Database layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)