### PR TITLE
Add GitHub Actions CI for macOS and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  macos:
+    name: macOS (Xcode)
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build RockyCore
+        run: swift build --package-path RockyCore
+
+      - name: Test RockyCore
+        run: swift test --package-path RockyCore
+
+      - name: Build RockyCLI
+        run: swift build --package-path RockyCLI
+
+  linux:
+    name: Linux (Ubuntu)
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SQLite
+        run: apt-get update && apt-get install -y libsqlite3-dev
+
+      - name: Build RockyCore
+        run: swift build --package-path RockyCore
+
+      - name: Test RockyCore
+        run: swift test --package-path RockyCore
+
+      - name: Build RockyCLI
+        run: swift build --package-path RockyCLI


### PR DESCRIPTION
## Summary

- Adds CI workflow that runs on every PR and push to main
- **macOS**: `macos-26` runner with Xcode 26 (Swift 6.2)
- **Linux**: `ubuntu-latest` with `swift:6.2` Docker container
- Builds both RockyCore and RockyCLI on each platform
- Runs RockyCore tests (49 tests) on each platform

Closes #30

## Test plan

- [x] Workflow triggers on this PR
- [ ] macOS job passes (build + test)
- [ ] Linux job passes (build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)