### PR TITLE
Add release workflow for platform-specific binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    name: macOS (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-26
+          - arch: x86_64
+            runner: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build release binary
+        run: swift build -c release --package-path RockyCLI --arch ${{ matrix.arch }}
+
+      - name: Package binary
+        run: |
+          BIN_PATH=$(swift build -c release --package-path RockyCLI --arch ${{ matrix.arch }} --show-bin-path)
+          cp "$BIN_PATH/RockyCLI" rocky
+          chmod +x rocky
+          tar czf rocky-macos-${{ matrix.arch }}.tar.gz rocky
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rocky-macos-${{ matrix.arch }}
+          path: rocky-macos-${{ matrix.arch }}.tar.gz
+
+  build-linux:
+    name: Linux (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: swift:6.2
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SQLite
+        run: apt-get update && apt-get install -y libsqlite3-dev
+
+      - name: Build release binary
+        run: swift build -c release --package-path RockyCLI
+
+      - name: Package binary
+        run: |
+          BIN_PATH=$(swift build -c release --package-path RockyCLI --show-bin-path)
+          cp "$BIN_PATH/RockyCLI" rocky
+          chmod +x rocky
+          tar czf rocky-linux-${{ matrix.arch }}.tar.gz rocky
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rocky-linux-${{ matrix.arch }}
+          path: rocky-linux-${{ matrix.arch }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: [build-macos, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            artifacts/*.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds release workflow triggered on version tags (`v*`)
- Builds 4 platform-specific binaries:
  - `rocky-macos-arm64.tar.gz` (Apple Silicon)
  - `rocky-macos-x86_64.tar.gz` (Intel Mac)
  - `rocky-linux-arm64.tar.gz` (ARM Linux)
  - `rocky-linux-x86_64.tar.gz` (x86_64 Linux)
- Creates a GitHub Release with auto-generated notes and all artifacts attached
- Binary is named `rocky` (not `RockyCLI`)

Closes #32

## Test plan

- [ ] CI passes on this PR (existing build/test workflow)
- [ ] After merge, push a tag (`git tag v0.1.0 && git push --tags`) to trigger the release workflow
- [ ] Verify all 4 binaries are attached to the GitHub Release
- [ ] Download and run binary on macOS to verify it works

## Next steps

- Create `argylebits/homebrew-tap` repo with formula pointing to release assets
- Formula auto-detects OS + architecture for the correct download

🤖 Generated with [Claude Code](https://claude.com/claude-code)