### PR TITLE
Add vertical padding to command output

### DIFF
--- a/RockyCLI/Sources/RockyCLI/Commands/Projects.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Projects.swift
@@ -13,10 +13,10 @@ struct Projects: AsyncParsableCommand {
         let projects = try await ctx.projectService.list()
 
         if projects.isEmpty {
-            print("No projects found.")
+            output("No projects found.")
             return
         }
 
-        print(Table.renderProjects(projects))
+        output(Table.renderProjects(projects))
     }
 }

--- a/RockyCLI/Sources/RockyCLI/Commands/Start.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Start.swift
@@ -21,12 +21,13 @@ struct Start: AsyncParsableCommand {
         }
 
         try await ctx.sessionService.start(projectId: proj.id)
-        print("Started \(proj.name)")
 
+        var message = "Started \(proj.name)"
         let running = try await ctx.sessionService.getRunningWithProjects()
         if running.count > 1 {
             let names = running.map(\.1.name).joined(separator: ", ")
-            print("Currently running: \(names)")
+            message += "\nCurrently running: \(names)"
         }
+        output(message)
     }
 }

--- a/RockyCLI/Sources/RockyCLI/Commands/Status.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Status.swift
@@ -49,7 +49,7 @@ struct Status: AsyncParsableCommand {
         // No time range flags — show current status
         if !today && !week && !month && !year && from == nil {
             let statuses = try await ctx.reportService.allProjectsWithStatus()
-            print(Table.renderStatus(statuses))
+            output(Table.renderStatus(statuses))
             return
         }
 
@@ -60,10 +60,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = dayRange(for: now, calendar: calendar)
             if verbose {
                 let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderVerbose(sessions, period: Formatter.periodToday(), projectFilter: project))
+                output(Table.renderVerbose(sessions, period: Formatter.periodToday(), projectFilter: project))
             } else {
                 let totals = try await ctx.reportService.totals(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderTodayTotals(totals, period: Formatter.periodToday()))
+                output(Table.renderTodayTotals(totals, period: Formatter.periodToday()))
             }
             return
         }
@@ -73,10 +73,10 @@ struct Status: AsyncParsableCommand {
             let period = Formatter.periodRange(from: start, to: endOfToday)
             if verbose {
                 let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderVerbose(sessions, period: period, projectFilter: project))
+                output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
                 let report = try await ctx.reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project))
+                output(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
         }
@@ -86,10 +86,10 @@ struct Status: AsyncParsableCommand {
             let period = Formatter.periodMonth(date: now)
             if verbose {
                 let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderVerbose(sessions, period: period, projectFilter: project))
+                output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
                 let report = try await ctx.reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project))
+                output(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
         }
@@ -99,10 +99,10 @@ struct Status: AsyncParsableCommand {
             let period = Formatter.periodYear(date: now)
             if verbose {
                 let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderVerbose(sessions, period: period, projectFilter: project))
+                output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
                 let report = try await ctx.reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
+                output(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
             return
         }
@@ -127,16 +127,16 @@ struct Status: AsyncParsableCommand {
 
             if verbose {
                 let sessions = try await ctx.reportService.verboseSessions(from: fromDate, to: toDate, projectId: projectId)
-                print(Table.renderVerbose(sessions, period: period, projectFilter: project))
+                output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else if days <= 7 {
                 let report = try await ctx.reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project))
+                output(Table.renderGrouped(report, period: period, projectFilter: project))
             } else if days <= 60 {
                 let report = try await ctx.reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project))
+                output(Table.renderGrouped(report, period: period, projectFilter: project))
             } else {
                 let report = try await ctx.reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
-                print(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
+                output(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
         }
     }

--- a/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
+++ b/RockyCLI/Sources/RockyCLI/Commands/Stop.swift
@@ -31,18 +31,19 @@ struct Stop: AsyncParsableCommand {
         let running = try await ctx.sessionService.getRunningWithProjects()
 
         if running.isEmpty {
-            print("No timers currently running.")
+            output("No timers currently running.")
             return
         }
 
         if running.count == 1 {
             let (_, proj) = running[0]
             let stopped = try await ctx.sessionService.stop(projectId: proj.id)
-            print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
+            output("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
             return
         }
 
         // Multiple running — interactive prompt
+        print()
         print(Table.renderRunningTimers(running))
         print()
 
@@ -58,7 +59,7 @@ struct Stop: AsyncParsableCommand {
             if let num = Int(input), num >= 1, num <= running.count {
                 let (_, proj) = running[num - 1]
                 let stopped = try await ctx.sessionService.stop(projectId: proj.id)
-                print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
+                output("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
                 return
             }
 
@@ -71,13 +72,13 @@ struct Stop: AsyncParsableCommand {
             throw ValidationError("No project found with name \"\(name)\".")
         }
         let stopped = try await ctx.sessionService.stop(projectId: proj.id)
-        print("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
+        output("Stopped \(proj.name) (\(Formatter.duration(stopped.duration())))")
     }
 
     private func stopAll(ctx: AppContext) async throws {
         let stopped = try await ctx.sessionService.stopAll()
         if stopped.isEmpty {
-            print("No timers currently running.")
+            output("No timers currently running.")
             return
         }
 
@@ -89,9 +90,10 @@ struct Stop: AsyncParsableCommand {
         }
 
         let maxName = entries.map(\.name.count).max() ?? 0
-        for entry in entries {
+        let lines = entries.map { entry in
             let padded = entry.name.padding(toLength: maxName, withPad: " ", startingAt: 0)
-            print("Stopped \(padded)  (\(entry.duration))")
+            return "Stopped \(padded)  (\(entry.duration))"
         }
+        output(lines.joined(separator: "\n"))
     }
 }

--- a/RockyCLI/Sources/RockyCLI/Output/Output.swift
+++ b/RockyCLI/Sources/RockyCLI/Output/Output.swift
@@ -1,0 +1,5 @@
+func output(_ text: String) {
+    print()
+    print(text)
+    print()
+}


### PR DESCRIPTION
## Summary

- Adds `output()` helper in `Output.swift` — single place for padded terminal output
- All commands use `output()` instead of `print()` for formatted output
- One blank line above and below all output for cleaner readability
- Error messages (thrown via `ValidationError`) are not padded
- Interactive prompts (multi-timer stop) pad the table but not the prompt line

Closes #35

## Test plan

- [x] `swift build` succeeds
- [x] Smoke test: `rocky status` shows padding
- [x] Start/stop messages have padding
- [x] Error messages remain unpadded

🤖 Generated with [Claude Code](https://claude.com/claude-code)