### PR TITLE
Remove CI job name overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   macos:
-    name: macOS (Xcode)
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +22,6 @@ jobs:
         run: swift build --package-path RockyCLI
 
   linux:
-    name: Linux (Ubuntu)
     runs-on: ubuntu-latest
     container:
       image: swift:6.2


### PR DESCRIPTION
## Summary
- Remove `name:` overrides from CI jobs so they display as `macos`/`linux` instead of `macOS (Xcode)`/`Linux (Ubuntu)`
- Standardizes CI job naming across argylebits repos (Kolache, Lederhosen, Rocky)

## After merge
Branch protection needs to be updated to require `macos`/`linux` instead of `macOS (Xcode)`/`Linux (Ubuntu)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)