### PR TITLE
Add dashboard and edit docs to OUTPUT.md and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ Show an analytics dashboard with trends and insights.
 rocky dashboard
 ```
 
-Displays a full-screen dashboard including:
+Displays a full-width dashboard including:
 - Running timers
-- Time summaries (this week, last week, this month, last month, this year)
-- Activity heatmap (12 weeks, Mon-Sun grid)
-- Weekly sparkline trend
+- Time summaries with deltas (this week, this month, this year)
+- Activity heatmap (31 weeks, Mon–Sun grid)
+- Weekly trend sparkline (31 weeks with month labels)
 - Project distribution for the current week
 - Peak working hours
-- Streaks and stats (current/longest streak, average/longest session, most active day)
+- Streaks & stats (streak, sessions, daily avg, total hours, top project, and more)
 
 ### `rocky edit [project] [flags]`
 

--- a/RockyDocs/COMMANDS.md
+++ b/RockyDocs/COMMANDS.md
@@ -129,13 +129,14 @@ rocky dashboard
 - No flags — displays a full-width dashboard with multiple analytics widgets
 - Widgets include:
   - Running timers (if any)
-  - Time summaries: this week, last week, this month, last month, this year (with week/month deltas)
-  - Activity heatmap: 12-week grid (Mon-Sun rows, week columns) with intensity levels `· ░ ▒ ▓ █`
-  - Weekly sparkline: 12-week trend using `▁▂▃▄▅▆▇█` characters
+  - Time summaries: this week, this month, this year (with week/month deltas showing change from previous period)
+  - Activity heatmap: 31-week grid (Mon-Sun rows, week columns) with intensity levels `· ░ ▒ ▓ █`
+  - Weekly trend: 31-week sparkline using `▁▂▃▄▅▆▇█` characters with month labels
   - Project distribution: bar chart for current week with percentage breakdown
-  - Peak hours: intensity chart showing busiest hours of the day
-  - Streaks & stats: current/longest streak, average/longest session, most active weekday
-- Dashboard uses double-line border `╔═╗║╚═╝` for outer frame and rounded single-line `╭─╮│╰─╯` for widget borders
+  - Peak hours: intensity chart showing busiest hours of the day (24h format)
+  - Streaks & stats: two-column layout with current/longest streak, sessions this week, daily avg, avg/longest session, total hours, most active day, best day this week, top project
+- All widgets render full-width with uniform padding inside rounded single-line borders `╭─╮│╰─╯`
+- Dashboard uses double-line border `╔═╗║╚═╝` for outer frame
 - All data computed from session history — no additional database tables required
 - Week starts on Monday (per DECISIONS.md)
 

--- a/RockyDocs/OUTPUT.md
+++ b/RockyDocs/OUTPUT.md
@@ -180,6 +180,90 @@ Period:  Mon 02 Mar — Fri 06 Mar 2026
 
 ---
 
+## rocky edit (interactive)
+
+Shows recent sessions for the project, prompts for selection and field to edit.
+
+```
+Sessions for rocky:
+
+   ID   Date   Start      Stop   Duration
+──────────────────────────────────────────
+   41   Mon    23:20     10:14    10h 54m
+▶  42   Tue    17:05   running     0h 05m
+──────────────────────────────────────────
+
+Edit which? 41
+
+  Mon 09 Mar    23:20 — 10:14    10h 54m
+
+  1. Start    (23:20)
+  2. Stop     (10:14)
+  3. Duration (10h 54m)
+
+Edit which field? 3
+New value (seconds): 7800
+
+Updated: Mon 09 Mar  23:20 — 01:30  (2h 10m)
+```
+
+**Rules:**
+- `▶` on rows where the timer is still running
+- `running` shown in Stop column for active sessions
+- Sessions sorted by date then start time
+- Field menu shows current values in parentheses
+- On success, prints updated session with new times and duration
+
+## rocky edit (non-interactive)
+
+```
+Updated: Mon 09 Mar  23:00 — 01:30  (2h 30m)
+```
+
+**Rules:**
+- Single confirmation line showing updated session details
+- On error, prints descriptive error and exits with code 1
+
+---
+
+## rocky dashboard
+
+Displays a full-width analytics dashboard inside a double-line outer frame (`╔═╗║╚═╝`). Each widget is wrapped in a rounded single-line box (`╭─╮│╰─╯`) with uniform padding.
+
+Layout constants: outer padding = 2, inner width = 70, total width = 74, widget box inner = 68, content width = 64.
+
+### Widgets (in order)
+
+**Running** — Lists active timers with `▶` prefix and elapsed duration. Shows "No timers running." if none.
+
+**Time Summary** — Three rows: This Week, This Month, This Year. Durations right-aligned. Week and month rows show delta arrows (`↑`/`↓`) with duration change from previous period, column-aligned.
+
+```
+This Week      2h 30m  ↑  1h 15m from last week
+This Month    12h 00m  ↓  3h 00m from last month
+This Year     48h
+```
+
+**Activity Heatmap** — 31-week grid, 7 rows (Mon–Sun), month labels across top. Intensity characters: `·` none, `░` light, `▒` moderate, `▓` busy, `█` heavy. Day labels use single-character abbreviations. Columns separated by 1 space, no trailing space on last column.
+
+**Weekly Trend** — 31-week sparkline using `▁▂▃▄▅▆▇█` characters. Each week's bar width is proportional to fill the full content width. Month labels below.
+
+**Projects This Week** — Bar chart with project names, filled/empty bar segments, percentage, and duration. Bars scaled to 100% (not to largest project). Project names capped at half the available flex width.
+
+**Peak Hours** — Two-column intensity chart showing activity level per hour (0–23) in 24h format. Uses same intensity characters as heatmap.
+
+**Streaks & Stats** — Two-column layout, 5 rows each:
+
+| Left column | Right column |
+|-------------|-------------|
+| Current streak | Daily avg (week) |
+| Longest streak | Avg session |
+| Sessions (week) | Total hours |
+| Longest session | Best day (week) |
+| Most active day | Top project |
+
+---
+
 ## General formatting rules
 
 - Column widths: pad all columns to consistent width based on content


### PR DESCRIPTION
## Summary
- Add dashboard widget output documentation to OUTPUT.md (was missing entirely)
- Add edit command output documentation to OUTPUT.md (was missing entirely)
- Update COMMANDS.md dashboard section to reflect 31-week heatmap/sparkline and two-column stats layout
- Update README dashboard description to match current implementation

## Test plan
- [x] Documentation review — all widget descriptions match current renderer output
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)