### PR TITLE
Update integration tests and use explicit ISO8601 date formatting

### DIFF
--- a/Sources/RockyCore/Database/Date+ISO8601.swift
+++ b/Sources/RockyCore/Database/Date+ISO8601.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension Date {
+    /// Formats as ISO8601 with Z suffix, matching Rocky's stored date format.
+    var iso8601String: String {
+        ISO8601DateFormatter().string(from: self)
+    }
+
+    /// Parses an ISO8601 string with Z suffix into a Date.
+    static func fromISO8601(_ string: String) -> Date? {
+        ISO8601DateFormatter().date(from: string)
+    }
+}

--- a/Sources/RockyCore/Models/Project.swift
+++ b/Sources/RockyCore/Models/Project.swift
@@ -22,15 +22,20 @@ public struct Project: Codable, Sendable {
     }
 }
 
-extension Project: FetchableRecord, PersistableRecord, TableRecord {
+extension Project: FetchableRecord, TableRecord {
     public static let databaseTableName = "projects"
 
-    public static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
-        .iso8601
-    }
-
-    public static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
-        .iso8601
+    public init(row: Row) throws {
+        let createdAtString: String = row["created_at"]
+        guard let createdAt = Date.fromISO8601(createdAtString) else {
+            throw RockyCoreError.invalidRow("projects")
+        }
+        self.init(
+            id: row["id"],
+            parentId: row["parent_id"],
+            name: row["name"],
+            createdAt: createdAt
+        )
     }
 }
 

--- a/Sources/RockyCore/Models/Session.swift
+++ b/Sources/RockyCore/Models/Session.swift
@@ -29,14 +29,30 @@ public struct Session: Codable, Sendable {
     }
 }
 
-extension Session: FetchableRecord, PersistableRecord, TableRecord {
+extension Session: FetchableRecord, TableRecord {
     public static let databaseTableName = "sessions"
 
-    public static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
-        .iso8601
-    }
+    public init(row: Row) throws {
+        let startTimeString: String = row["start_time"]
+        guard let startTime = Date.fromISO8601(startTimeString) else {
+            throw RockyCoreError.invalidRow("sessions")
+        }
 
-    public static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
-        .iso8601
+        let endTime: Date?
+        if let endTimeString: String = row["end_time"] {
+            guard let parsed = Date.fromISO8601(endTimeString) else {
+                throw RockyCoreError.invalidRow("sessions")
+            }
+            endTime = parsed
+        } else {
+            endTime = nil
+        }
+
+        self.init(
+            id: row["id"],
+            projectId: row["project_id"],
+            startTime: startTime,
+            endTime: endTime
+        )
     }
 }

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
@@ -15,7 +15,7 @@ public struct SQLiteProjectRepository: ProjectRepository, Sendable {
         return try await db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO projects (name, created_at) VALUES (?, ?)",
-                arguments: [name, Date()])
+                arguments: [name, Date().iso8601String])
             let id = db.lastInsertedRowID
             return try Project.fetchOne(db,
                 sql: "SELECT * FROM projects WHERE id = ?",

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
@@ -12,7 +12,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         try await db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO sessions (project_id, start_time) VALUES (?, ?)",
-                arguments: [projectId, Date()])
+                arguments: [projectId, Date().iso8601String])
         }
     }
 
@@ -34,7 +34,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
             }
             try db.execute(
                 sql: "UPDATE sessions SET end_time = ? WHERE id = ?",
-                arguments: [Date(), session.id])
+                arguments: [Date().iso8601String, session.id])
             return try Session.fetchOne(db,
                 sql: "SELECT * FROM sessions WHERE id = ?",
                 arguments: [session.id])!
@@ -45,7 +45,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         try await db.dbQueue.write { db in
             let running = try Session.fetchAll(db,
                 sql: "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC")
-            let now = Date()
+            let now = Date().iso8601String
             var stopped: [Session] = []
             for session in running {
                 try db.execute(
@@ -79,11 +79,15 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
                 """)
             return try rows.map { row in
                 let session = try Session(row: row)
+                let pCreatedAtString: String = row["p_created_at"]
+                guard let pCreatedAt = Date.fromISO8601(pCreatedAtString) else {
+                    throw RockyCoreError.invalidRow("projects")
+                }
                 let project = Project(
                     id: row["p_id"],
                     parentId: row["p_parent_id"],
                     name: row["p_name"],
-                    createdAt: row["p_created_at"])
+                    createdAt: pCreatedAt)
                 return (session, project)
             }
         }
@@ -93,7 +97,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         try await db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO sessions (project_id, start_time, end_time) VALUES (?, ?, ?)",
-                arguments: [projectId, startTime, endTime])
+                arguments: [projectId, startTime.iso8601String, endTime?.iso8601String])
         }
     }
 
@@ -109,7 +113,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         try await db.dbQueue.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET start_time = ?, end_time = ? WHERE id = ?",
-                arguments: [startTime, endTime, id])
+                arguments: [startTime.iso8601String, endTime?.iso8601String, id])
             return try Session.fetchOne(db,
                 sql: "SELECT * FROM sessions WHERE id = ?",
                 arguments: [id])!
@@ -125,7 +129,7 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
                 JOIN projects p ON s.project_id = p.id
                 WHERE (s.start_time < ? AND (s.end_time > ? OR s.end_time IS NULL))
                 """
-            var arguments: [any DatabaseValueConvertible] = [to, from]
+            var arguments: [any DatabaseValueConvertible] = [to.iso8601String, from.iso8601String]
 
             if let projectId {
                 sql += " AND s.project_id = ?"
@@ -136,11 +140,15 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
             let rows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(arguments))
             return try rows.map { row in
                 let session = try Session(row: row)
+                let pCreatedAtString: String = row["p_created_at"]
+                guard let pCreatedAt = Date.fromISO8601(pCreatedAtString) else {
+                    throw RockyCoreError.invalidRow("projects")
+                }
                 let project = Project(
                     id: row["p_id"],
                     parentId: row["p_parent_id"],
                     name: row["p_name"],
-                    createdAt: row["p_created_at"])
+                    createdAt: pCreatedAt)
                 return (session, project)
             }
         }

--- a/Tests/RockyCoreTests/SQLiteIntegrationTests.swift
+++ b/Tests/RockyCoreTests/SQLiteIntegrationTests.swift
@@ -6,17 +6,19 @@ actor TestDatabase {
     static let shared = TestDatabase()
     private var db: Database?
 
-    func get() async throws -> Database {
+    func get() throws -> Database {
         if let db { return db }
-        let db = try await Database.open(at: ":memory:")
+        let db = try Database.inMemory()
         self.db = db
         return db
     }
 
     func reset() async throws {
-        let db = try await get()
-        try await db.execute("DELETE FROM sessions")
-        try await db.execute("DELETE FROM projects")
+        let db = try get()
+        try await db.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM sessions")
+            try db.execute(sql: "DELETE FROM projects")
+        }
     }
 }
 
@@ -26,29 +28,34 @@ struct SQLiteIntegrationTests {
     @Test("Tables exist after migration")
     func tablesExist() async throws {
         let db = try await TestDatabase.shared.get()
-        let tables = try await db.query(
-            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
-        )
-        let names = tables.compactMap { $0.column("name")?.string }
-        #expect(names.contains("projects"))
-        #expect(names.contains("sessions"))
-        #expect(names.contains("migrations"))
+        let tables = try await db.dbQueue.read { db in
+            try String.fetchAll(db, sql:
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        }
+        #expect(tables.contains("projects"))
+        #expect(tables.contains("sessions"))
     }
 
-    @Test("Migration version is 1")
-    func migrationVersion() async throws {
+    @Test("GRDB migrations table exists")
+    func grdbMigrationsExist() async throws {
         let db = try await TestDatabase.shared.get()
-        let rows = try await db.query("SELECT version FROM migrations")
-        #expect(rows.count == 1)
-        #expect(rows[0].column("version")?.integer == 1)
+        let tables = try await db.dbQueue.read { db in
+            try String.fetchAll(db, sql:
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'grdb%'")
+        }
+        #expect(!tables.isEmpty)
     }
 
     @Test("Migrations are idempotent")
     func migrationsIdempotent() async throws {
         let db = try await TestDatabase.shared.get()
-        try await Migrations.run(on: db)
-        let rows = try await db.query("SELECT version FROM migrations")
-        #expect(rows.count == 1)
+        try Migrations.run(on: db)
+        let tables = try await db.dbQueue.read { db in
+            try String.fetchAll(db, sql:
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        }
+        #expect(tables.contains("projects"))
+        #expect(tables.contains("sessions"))
     }
 
     @Test("SQLiteProjectRepository round-trips project data")


### PR DESCRIPTION
## Summary

Closes #86

### Date formatting approach

Removed GRDB's `databaseDateEncodingStrategy`/`databaseDateDecodingStrategy` from models. All date formatting is now fully explicit:

- **Writing**: `Date().iso8601String` formats dates before passing to raw SQL
- **Reading**: Custom `init(row:)` on models parses date strings via `Date.fromISO8601()`
- **Helper**: `Date+ISO8601.swift` provides `iso8601String` and `fromISO8601` extensions

This ensures one consistent mechanism for date encoding/decoding with no hidden behavior.

### Test changes

- `TestDatabase` updated to use `Database.inMemory()` and `dbQueue.read/write`
- Replaced old migration table tests with GRDB migration table tests
- All integration tests pass with the new GRDB-based repositories

### Model changes

- Removed `PersistableRecord` conformance (not needed with raw SQL)
- Added custom `init(row:)` for explicit date parsing
- Kept `FetchableRecord` and `TableRecord` for `fetchOne`/`fetchAll` support

## Test plan

- [x] All 133 tests pass
- [x] `swift build` succeeds