### PR TITLE
Drop async/await from entire stack

### DIFF
--- a/Sources/App/AppContext.swift
+++ b/Sources/App/AppContext.swift
@@ -12,7 +12,7 @@ struct AppContext {
         self.dashboardService = dashboardService
     }
 
-    static func build() async throws -> AppContext {
+    static func build() throws -> AppContext {
         let db = try Database.open()
         let projectRepo = SQLiteProjectRepository(db: db)
         let sessionRepo = SQLiteSessionRepository(db: db)

--- a/Sources/App/Commands/Dashboard.swift
+++ b/Sources/App/Commands/Dashboard.swift
@@ -2,15 +2,15 @@ import ArgumentParser
 import Foundation
 import RockyCore
 
-struct Dashboard: AsyncParsableCommand {
+struct Dashboard: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Show an analytics dashboard with trends and insights."
     )
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
-        let data = try await ctx.dashboardService.generate()
+        let data = try ctx.dashboardService.generate()
         output(DashboardRenderer.render(data))
     }
 }

--- a/Sources/App/Commands/Edit.swift
+++ b/Sources/App/Commands/Edit.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import RockyCore
 
-struct Edit: AsyncParsableCommand {
+struct Edit: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Edit the start, stop, or duration of a session."
     )
@@ -22,13 +22,13 @@ struct Edit: AsyncParsableCommand {
     @Option(name: .long, help: "Duration in seconds.")
     var duration: Double?
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
         if let sessionId = session {
-            try await nonInteractive(sessionId: sessionId, ctx: ctx)
+            try nonInteractive(sessionId: sessionId, ctx: ctx)
         } else if let projectName = project {
-            try await interactive(projectName: projectName, ctx: ctx)
+            try interactive(projectName: projectName, ctx: ctx)
         } else {
             throw ValidationError("Provide a project name for interactive mode or --session for non-interactive mode.")
         }
@@ -36,11 +36,11 @@ struct Edit: AsyncParsableCommand {
 
     // MARK: - Non-interactive
 
-    private func nonInteractive(sessionId: Int, ctx: AppContext) async throws {
+    private func nonInteractive(sessionId: Int, ctx: AppContext) throws {
         let newStart = try start.map { try DateTimeFormat.parse($0) }
         let newStop = try stop.map { try DateTimeFormat.parse($0) }
 
-        let updated = try await ctx.sessionService.editSession(
+        let updated = try ctx.sessionService.editSession(
             id: sessionId,
             newStart: newStart,
             newStop: newStop,
@@ -52,15 +52,15 @@ struct Edit: AsyncParsableCommand {
 
     // MARK: - Interactive
 
-    private func interactive(projectName: String, ctx: AppContext) async throws {
-        guard let proj = try await ctx.projectService.getByName(projectName) else {
+    private func interactive(projectName: String, ctx: AppContext) throws {
+        guard let proj = try ctx.projectService.getByName(projectName) else {
             throw ValidationError("No project found with name \"\(projectName)\".")
         }
 
         let calendar = Calendar.current
         let to = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: Date()))!
         let from = calendar.date(byAdding: .day, value: -90, to: to)!
-        let sessions = try await ctx.sessionService.getSessions(from: from, to: to, projectId: proj.id)
+        let sessions = try ctx.sessionService.getSessions(from: from, to: to, projectId: proj.id)
 
         if sessions.isEmpty {
             output("No sessions found for \(proj.name).")
@@ -77,7 +77,7 @@ struct Edit: AsyncParsableCommand {
 
         let sessionId = try promptForSessionId(sessions: sessions.map(\.0))
 
-        guard let existing = try await ctx.sessionService.getById(sessionId) else {
+        guard let existing = try ctx.sessionService.getById(sessionId) else {
             throw ValidationError("No session found with ID \(sessionId).")
         }
 
@@ -98,15 +98,15 @@ struct Edit: AsyncParsableCommand {
         switch field {
         case .start:
             let newStart = try promptForDatetime("New value (YYYY-MM-DD HH:MM): ")
-            let updated = try await ctx.sessionService.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
+            let updated = try ctx.sessionService.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
             printSessionSummary(updated)
         case .stop:
             let newStop = try promptForDatetime("New value (YYYY-MM-DD HH:MM): ")
-            let updated = try await ctx.sessionService.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
+            let updated = try ctx.sessionService.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
             printSessionSummary(updated)
         case .duration:
             let newDuration = try promptForDuration()
-            let updated = try await ctx.sessionService.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: newDuration)
+            let updated = try ctx.sessionService.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: newDuration)
         }
     }
 

--- a/Sources/App/Commands/Projects.swift
+++ b/Sources/App/Commands/Projects.swift
@@ -1,15 +1,15 @@
 import ArgumentParser
 import RockyCore
 
-struct Projects: AsyncParsableCommand {
+struct Projects: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "List all projects."
     )
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
-        let projects = try await ctx.projectService.list()
+        let projects = try ctx.projectService.list()
 
         if projects.isEmpty {
             output("No projects found.")

--- a/Sources/App/Commands/Start.swift
+++ b/Sources/App/Commands/Start.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import RockyCore
 
-struct Start: AsyncParsableCommand {
+struct Start: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Start a timer for a project."
     )
@@ -9,20 +9,20 @@ struct Start: AsyncParsableCommand {
     @Argument(help: "The project name to start tracking.")
     var project: String
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
-        let proj = try await ctx.projectService.findOrCreate(name: project)
+        let proj = try ctx.projectService.findOrCreate(name: project)
 
         let autoStop = try ConfigFile.getBool("auto-stop", default: true)
-        if autoStop, try await ctx.sessionService.hasRunningSession(projectId: proj.id) {
+        if autoStop, try ctx.sessionService.hasRunningSession(projectId: proj.id) {
             throw ValidationError("Timer already running for \(proj.name)")
         }
 
-        try await ctx.sessionService.start(projectId: proj.id)
+        try ctx.sessionService.start(projectId: proj.id)
 
         var message = "Started \(proj.name)"
-        let running = try await ctx.sessionService.getRunningWithProjects()
+        let running = try ctx.sessionService.getRunningWithProjects()
         if running.count > 1 {
             let names = running.map(\.1.name).joined(separator: ", ")
             message += "\nCurrently running: \(names)"

--- a/Sources/App/Commands/Status.swift
+++ b/Sources/App/Commands/Status.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import RockyCore
 
-struct Status: AsyncParsableCommand {
+struct Status: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Show time tracking summary."
     )
@@ -31,15 +31,15 @@ struct Status: AsyncParsableCommand {
     @Option(name: .long, help: "Filter to a single project.")
     var project: String?
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
         let calendar = Calendar.current
 
         // Resolve project filter
         var projectId: Int? = nil
         if let projectName = project {
-            guard let proj = try await ctx.projectService.getByName(projectName) else {
+            guard let proj = try ctx.projectService.getByName(projectName) else {
                 throw ValidationError("No project found with name \"\(projectName)\".")
             }
             projectId = proj.id
@@ -47,7 +47,7 @@ struct Status: AsyncParsableCommand {
 
         // No time range flags — show current status
         if !today && !week && !month && !year && from == nil {
-            let statuses = try await ctx.reportService.allProjectsWithStatus()
+            let statuses = try ctx.reportService.allProjectsWithStatus()
             output(Table.renderStatus(statuses))
             return
         }
@@ -58,10 +58,10 @@ struct Status: AsyncParsableCommand {
         if today {
             let (start, _) = dayRange(for: now, calendar: calendar)
             if verbose {
-                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderVerbose(sessions, period: Date().formatted(DateTimeFormat.fullDate), projectFilter: project))
             } else {
-                let totals = try await ctx.reportService.totals(from: start, to: endOfToday, projectId: projectId)
+                let totals = try ctx.reportService.totals(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderTodayTotals(totals, period: Date().formatted(DateTimeFormat.fullDate)))
             }
             return
@@ -71,10 +71,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = weekRange(for: now, calendar: calendar)
             let period = DateTimeFormat.periodRange(from: start, to: endOfToday)
             if verbose {
-                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await ctx.reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
+                let report = try ctx.reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
@@ -84,10 +84,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = monthRange(for: now, calendar: calendar)
             let period = now.formatted(DateTimeFormat.monthYear)
             if verbose {
-                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await ctx.reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
+                let report = try ctx.reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project))
             }
             return
@@ -97,10 +97,10 @@ struct Status: AsyncParsableCommand {
             let (start, _) = yearRange(for: now, calendar: calendar)
             let period = now.formatted(DateTimeFormat.year)
             if verbose {
-                let sessions = try await ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
+                let sessions = try ctx.reportService.verboseSessions(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else {
-                let report = try await ctx.reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
+                let report = try ctx.reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
             return
@@ -125,16 +125,16 @@ struct Status: AsyncParsableCommand {
             let period = DateTimeFormat.periodRange(from: fromDate, to: toDate)
 
             if verbose {
-                let sessions = try await ctx.reportService.verboseSessions(from: fromDate, to: toDate, projectId: projectId)
+                let sessions = try ctx.reportService.verboseSessions(from: fromDate, to: toDate, projectId: projectId)
                 output(Table.renderVerbose(sessions, period: period, projectFilter: project))
             } else if days <= 7 {
-                let report = try await ctx.reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
+                let report = try ctx.reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project))
             } else if days <= 60 {
-                let report = try await ctx.reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
+                let report = try ctx.reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project))
             } else {
-                let report = try await ctx.reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
+                let report = try ctx.reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
                 output(Table.renderGrouped(report, period: period, projectFilter: project, hoursOnly: true))
             }
         }

--- a/Sources/App/Commands/Stop.swift
+++ b/Sources/App/Commands/Stop.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import RockyCore
 
-struct Stop: AsyncParsableCommand {
+struct Stop: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Stop a running timer."
     )
@@ -13,21 +13,21 @@ struct Stop: AsyncParsableCommand {
     @Flag(name: .long, help: "Stop all running timers.")
     var all: Bool = false
 
-    func run() async throws {
-        let ctx = try await AppContext.build()
+    func run() throws {
+        let ctx = try AppContext.build()
 
         if all {
-            try await stopAll(ctx: ctx)
+            try stopAll(ctx: ctx)
             return
         }
 
         if let projectName = project {
-            try await stopProject(name: projectName, ctx: ctx)
+            try stopProject(name: projectName, ctx: ctx)
             return
         }
 
         // No args — check running timers
-        let running = try await ctx.sessionService.getRunningWithProjects()
+        let running = try ctx.sessionService.getRunningWithProjects()
 
         if running.isEmpty {
             output("No timers currently running.")
@@ -36,7 +36,7 @@ struct Stop: AsyncParsableCommand {
 
         if running.count == 1 {
             let (_, proj) = running[0]
-            let stopped = try await ctx.sessionService.stop(projectId: proj.id)
+            let stopped = try ctx.sessionService.stop(projectId: proj.id)
             output("Stopped \(proj.name) (\(DurationFormat.formatted(stopped.duration())))")
             return
         }
@@ -54,13 +54,13 @@ struct Stop: AsyncParsableCommand {
             let input = line.trimmingCharacters(in: .whitespaces)
 
             if input == "all" {
-                try await stopAll(ctx: ctx)
+                try stopAll(ctx: ctx)
                 return
             }
 
             if let num = Int(input), num >= 1, num <= running.count {
                 let (_, proj) = running[num - 1]
-                let stopped = try await ctx.sessionService.stop(projectId: proj.id)
+                let stopped = try ctx.sessionService.stop(projectId: proj.id)
                 output("Stopped \(proj.name) (\(DurationFormat.formatted(stopped.duration())))")
                 return
             }
@@ -69,16 +69,16 @@ struct Stop: AsyncParsableCommand {
         }
     }
 
-    private func stopProject(name: String, ctx: AppContext) async throws {
-        guard let proj = try await ctx.projectService.getByName(name) else {
+    private func stopProject(name: String, ctx: AppContext) throws {
+        guard let proj = try ctx.projectService.getByName(name) else {
             throw ValidationError("No project found with name \"\(name)\".")
         }
-        let stopped = try await ctx.sessionService.stop(projectId: proj.id)
+        let stopped = try ctx.sessionService.stop(projectId: proj.id)
         output("Stopped \(proj.name) (\(DurationFormat.formatted(stopped.duration())))")
     }
 
-    private func stopAll(ctx: AppContext) async throws {
-        let stopped = try await ctx.sessionService.stopAll()
+    private func stopAll(ctx: AppContext) throws {
+        let stopped = try ctx.sessionService.stopAll()
         if stopped.isEmpty {
             output("No timers currently running.")
             return
@@ -86,7 +86,7 @@ struct Stop: AsyncParsableCommand {
 
         var entries: [(name: String, duration: String)] = []
         for session in stopped {
-            if let proj = try await ctx.projectService.getById(session.projectId) {
+            if let proj = try ctx.projectService.getById(session.projectId) {
                 entries.append((proj.name, DurationFormat.formatted(session.duration())))
             }
         }

--- a/Sources/App/Rocky.swift
+++ b/Sources/App/Rocky.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 
 @main
-struct Rocky: AsyncParsableCommand {
+struct Rocky: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "rocky",
         abstract: "A CLI time tracking tool.",

--- a/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
@@ -6,8 +6,8 @@ public final class MockProjectRepository: ProjectRepository, @unchecked Sendable
 
     public init() {}
 
-    public func findOrCreate(name: String) async throws -> Project {
-        if let existing = try await getByName(name) {
+    public func findOrCreate(name: String) throws -> Project {
+        if let existing = try getByName(name) {
             return existing
         }
         let project = Project(id: nextId, parentId: nil, name: name, createdAt: Date().addingTimeInterval(Double(nextId)))
@@ -16,15 +16,15 @@ public final class MockProjectRepository: ProjectRepository, @unchecked Sendable
         return project
     }
 
-    public func getById(_ id: Int) async throws -> Project? {
+    public func getById(_ id: Int) throws -> Project? {
         projects.first { $0.id == id }
     }
 
-    public func getByName(_ name: String) async throws -> Project? {
+    public func getByName(_ name: String) throws -> Project? {
         projects.first { $0.name.lowercased() == name.lowercased() }
     }
 
-    public func list() async throws -> [Project] {
+    public func list() throws -> [Project] {
         projects.sorted { $0.createdAt < $1.createdAt }
     }
 }

--- a/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
+++ b/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
@@ -9,17 +9,17 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
         self.projectRepository = projectRepository
     }
 
-    public func start(projectId: Int) async throws {
+    public func start(projectId: Int) throws {
         let session = Session(id: nextId, projectId: projectId, startTime: Date(), endTime: nil)
         nextId += 1
         sessions.append(session)
     }
 
-    public func hasRunningSession(projectId: Int) async throws -> Bool {
+    public func hasRunningSession(projectId: Int) throws -> Bool {
         sessions.contains { $0.projectId == projectId && $0.isRunning }
     }
 
-    public func stop(projectId: Int) async throws -> Session {
+    public func stop(projectId: Int) throws -> Session {
         guard let index = sessions.firstIndex(where: { $0.projectId == projectId && $0.isRunning }) else {
             throw RockyCoreError.noRunningTimers
         }
@@ -33,7 +33,7 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
         return stopped
     }
 
-    public func stopAll() async throws -> [Session] {
+    public func stopAll() throws -> [Session] {
         var stopped: [Session] = []
         for (index, session) in sessions.enumerated() where session.isRunning {
             let s = Session(
@@ -48,31 +48,31 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
         return stopped
     }
 
-    public func getRunning() async throws -> [Session] {
+    public func getRunning() throws -> [Session] {
         sessions.filter { $0.isRunning }.sorted { $0.startTime < $1.startTime }
     }
 
-    public func getRunningWithProjects() async throws -> [(Session, Project)] {
+    public func getRunningWithProjects() throws -> [(Session, Project)] {
         var results: [(Session, Project)] = []
         for session in sessions where session.isRunning {
-            if let project = try await projectRepository.getById(session.projectId) {
+            if let project = try projectRepository.getById(session.projectId) {
                 results.append((session, project))
             }
         }
         return results.sorted { $0.0.startTime < $1.0.startTime }
     }
 
-    public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
+    public func insert(projectId: Int, startTime: Date, endTime: Date?) throws {
         let session = Session(id: nextId, projectId: projectId, startTime: startTime, endTime: endTime)
         nextId += 1
         sessions.append(session)
     }
 
-    public func getById(_ id: Int) async throws -> Session? {
+    public func getById(_ id: Int) throws -> Session? {
         sessions.first { $0.id == id }
     }
 
-    public func update(id: Int, startTime: Date, endTime: Date?) async throws -> Session {
+    public func update(id: Int, startTime: Date, endTime: Date?) throws -> Session {
         guard let index = sessions.firstIndex(where: { $0.id == id }) else {
             throw RockyCoreError.sessionNotFound(id)
         }
@@ -81,7 +81,7 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
         return updated
     }
 
-    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) throws -> [(Session, Project)] {
         var results: [(Session, Project)] = []
         for session in sessions {
             if let projectId, session.projectId != projectId { continue }
@@ -89,7 +89,7 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
             let endTime = session.endTime ?? Date()
             let overlaps = session.startTime < to && endTime > from
             if overlaps {
-                if let project = try await projectRepository.getById(session.projectId) {
+                if let project = try projectRepository.getById(session.projectId) {
                     results.append((session, project))
                 }
             }

--- a/Sources/RockyCore/Repositories/ProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/ProjectRepository.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public protocol ProjectRepository: Sendable {
-    func findOrCreate(name: String) async throws -> Project
-    func getById(_ id: Int) async throws -> Project?
-    func getByName(_ name: String) async throws -> Project?
-    func list() async throws -> [Project]
+    func findOrCreate(name: String) throws -> Project
+    func getById(_ id: Int) throws -> Project?
+    func getByName(_ name: String) throws -> Project?
+    func list() throws -> [Project]
 }

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
@@ -8,11 +8,11 @@ public struct SQLiteProjectRepository: ProjectRepository, Sendable {
         self.db = db
     }
 
-    public func findOrCreate(name: String) async throws -> Project {
-        if let existing = try await getByName(name) {
+    public func findOrCreate(name: String) throws -> Project {
+        if let existing = try getByName(name) {
             return existing
         }
-        return try await db.dbQueue.write { db in
+        return try db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO projects (name, created_at) VALUES (?, ?)",
                 arguments: [name, Date().iso8601String])
@@ -23,24 +23,24 @@ public struct SQLiteProjectRepository: ProjectRepository, Sendable {
         }
     }
 
-    public func getById(_ id: Int) async throws -> Project? {
-        try await db.dbQueue.read { db in
+    public func getById(_ id: Int) throws -> Project? {
+        try db.dbQueue.read { db in
             try Project.fetchOne(db,
                 sql: "SELECT * FROM projects WHERE id = ?",
                 arguments: [id])
         }
     }
 
-    public func getByName(_ name: String) async throws -> Project? {
-        try await db.dbQueue.read { db in
+    public func getByName(_ name: String) throws -> Project? {
+        try db.dbQueue.read { db in
             try Project.fetchOne(db,
                 sql: "SELECT * FROM projects WHERE name = ? COLLATE NOCASE",
                 arguments: [name])
         }
     }
 
-    public func list() async throws -> [Project] {
-        try await db.dbQueue.read { db in
+    public func list() throws -> [Project] {
+        try db.dbQueue.read { db in
             try Project.fetchAll(db,
                 sql: "SELECT * FROM projects ORDER BY created_at ASC")
         }

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
@@ -8,16 +8,16 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         self.db = db
     }
 
-    public func start(projectId: Int) async throws {
-        try await db.dbQueue.write { db in
+    public func start(projectId: Int) throws {
+        try db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO sessions (project_id, start_time) VALUES (?, ?)",
                 arguments: [projectId, Date().iso8601String])
         }
     }
 
-    public func hasRunningSession(projectId: Int) async throws -> Bool {
-        try await db.dbQueue.read { db in
+    public func hasRunningSession(projectId: Int) throws -> Bool {
+        try db.dbQueue.read { db in
             let count = try Int.fetchOne(db,
                 sql: "SELECT COUNT(*) FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
                 arguments: [projectId])
@@ -25,8 +25,8 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         }
     }
 
-    public func stop(projectId: Int) async throws -> Session {
-        try await db.dbQueue.write { db in
+    public func stop(projectId: Int) throws -> Session {
+        try db.dbQueue.write { db in
             guard let session = try Session.fetchOne(db,
                 sql: "SELECT * FROM sessions WHERE project_id = ? AND end_time IS NULL LIMIT 1",
                 arguments: [projectId]) else {
@@ -41,8 +41,8 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         }
     }
 
-    public func stopAll() async throws -> [Session] {
-        try await db.dbQueue.write { db in
+    public func stopAll() throws -> [Session] {
+        try db.dbQueue.write { db in
             let running = try Session.fetchAll(db,
                 sql: "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC")
             let now = Date().iso8601String
@@ -60,15 +60,15 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         }
     }
 
-    public func getRunning() async throws -> [Session] {
-        try await db.dbQueue.read { db in
+    public func getRunning() throws -> [Session] {
+        try db.dbQueue.read { db in
             try Session.fetchAll(db,
                 sql: "SELECT * FROM sessions WHERE end_time IS NULL ORDER BY start_time ASC")
         }
     }
 
-    public func getRunningWithProjects() async throws -> [(Session, Project)] {
-        try await db.dbQueue.read { db in
+    public func getRunningWithProjects() throws -> [(Session, Project)] {
+        try db.dbQueue.read { db in
             let rows = try Row.fetchAll(db, sql: """
                 SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id,
                        p.name AS p_name, p.created_at AS p_created_at
@@ -93,24 +93,24 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         }
     }
 
-    public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
-        try await db.dbQueue.write { db in
+    public func insert(projectId: Int, startTime: Date, endTime: Date?) throws {
+        try db.dbQueue.write { db in
             try db.execute(
                 sql: "INSERT INTO sessions (project_id, start_time, end_time) VALUES (?, ?, ?)",
                 arguments: [projectId, startTime.iso8601String, endTime?.iso8601String])
         }
     }
 
-    public func getById(_ id: Int) async throws -> Session? {
-        try await db.dbQueue.read { db in
+    public func getById(_ id: Int) throws -> Session? {
+        try db.dbQueue.read { db in
             try Session.fetchOne(db,
                 sql: "SELECT * FROM sessions WHERE id = ?",
                 arguments: [id])
         }
     }
 
-    public func update(id: Int, startTime: Date, endTime: Date?) async throws -> Session {
-        try await db.dbQueue.write { db in
+    public func update(id: Int, startTime: Date, endTime: Date?) throws -> Session {
+        try db.dbQueue.write { db in
             try db.execute(
                 sql: "UPDATE sessions SET start_time = ?, end_time = ? WHERE id = ?",
                 arguments: [startTime.iso8601String, endTime?.iso8601String, id])
@@ -120,8 +120,8 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
         }
     }
 
-    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
-        try await db.dbQueue.read { db in
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) throws -> [(Session, Project)] {
+        try db.dbQueue.read { db in
             var sql = """
                 SELECT s.*, p.id AS p_id, p.parent_id AS p_parent_id,
                        p.name AS p_name, p.created_at AS p_created_at

--- a/Sources/RockyCore/Repositories/SessionRepository.swift
+++ b/Sources/RockyCore/Repositories/SessionRepository.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 public protocol SessionRepository: Sendable {
-    func start(projectId: Int) async throws
-    func hasRunningSession(projectId: Int) async throws -> Bool
-    func stop(projectId: Int) async throws -> Session
-    func stopAll() async throws -> [Session]
-    func getRunning() async throws -> [Session]
-    func getRunningWithProjects() async throws -> [(Session, Project)]
-    func insert(projectId: Int, startTime: Date, endTime: Date?) async throws
-    func getSessions(from: Date, to: Date, projectId: Int?) async throws -> [(Session, Project)]
-    func getById(_ id: Int) async throws -> Session?
-    func update(id: Int, startTime: Date, endTime: Date?) async throws -> Session
+    func start(projectId: Int) throws
+    func hasRunningSession(projectId: Int) throws -> Bool
+    func stop(projectId: Int) throws -> Session
+    func stopAll() throws -> [Session]
+    func getRunning() throws -> [Session]
+    func getRunningWithProjects() throws -> [(Session, Project)]
+    func insert(projectId: Int, startTime: Date, endTime: Date?) throws
+    func getSessions(from: Date, to: Date, projectId: Int?) throws -> [(Session, Project)]
+    func getById(_ id: Int) throws -> Session?
+    func update(id: Int, startTime: Date, endTime: Date?) throws -> Session
 }

--- a/Sources/RockyCore/Services/DashboardService.swift
+++ b/Sources/RockyCore/Services/DashboardService.swift
@@ -9,7 +9,7 @@ public struct DashboardService: Sendable {
         self.projectRepository = projectRepository
     }
 
-    public func generate(now: Date = Date()) async throws -> DashboardData {
+    public func generate(now: Date = Date()) throws -> DashboardData {
         var calendar = Calendar.current
         calendar.firstWeekday = 2 // Monday (per DECISIONS.md)
 
@@ -23,15 +23,15 @@ public struct DashboardService: Sendable {
 
         // Fetch sessions for recent range (covers summaries, heatmap, sparkline, peak hours, distribution)
         let earliestNeeded = [heatmapStart, thisYearStart, lastMonthStart, lastWeekStart].min()!
-        let recentSessions = try await sessionRepository.getSessions(from: earliestNeeded, to: now, projectId: nil)
+        let recentSessions = try sessionRepository.getSessions(from: earliestNeeded, to: now, projectId: nil)
 
         // Fetch full history for streaks and all-time stats
-        let allSessions = try await sessionRepository.getSessions(
+        let allSessions = try sessionRepository.getSessions(
             from: Date(timeIntervalSince1970: 0), to: now, projectId: nil
         )
 
         // Running timers
-        let runningPairs = try await sessionRepository.getRunningWithProjects()
+        let runningPairs = try sessionRepository.getRunningWithProjects()
         let runningTimers = runningPairs.map { session, project in
             RunningTimer(projectName: project.name, duration: session.duration(at: now))
         }

--- a/Sources/RockyCore/Services/ProjectService.swift
+++ b/Sources/RockyCore/Services/ProjectService.swift
@@ -7,19 +7,19 @@ public struct ProjectService: Sendable {
         self.repository = repository
     }
 
-    public func findOrCreate(name: String) async throws -> Project {
-        try await repository.findOrCreate(name: name)
+    public func findOrCreate(name: String) throws -> Project {
+        try repository.findOrCreate(name: name)
     }
 
-    public func getById(_ id: Int) async throws -> Project? {
-        try await repository.getById(id)
+    public func getById(_ id: Int) throws -> Project? {
+        try repository.getById(id)
     }
 
-    public func getByName(_ name: String) async throws -> Project? {
-        try await repository.getByName(name)
+    public func getByName(_ name: String) throws -> Project? {
+        try repository.getByName(name)
     }
 
-    public func list() async throws -> [Project] {
-        try await repository.list()
+    public func list() throws -> [Project] {
+        try repository.list()
     }
 }

--- a/Sources/RockyCore/Services/ReportService.swift
+++ b/Sources/RockyCore/Services/ReportService.swift
@@ -11,9 +11,9 @@ public struct ReportService: Sendable {
 
     // MARK: - Status (no flags)
 
-    public func allProjectsWithStatus() async throws -> [ProjectStatus] {
-        let projects = try await projectRepository.list()
-        let runningSessions = try await sessionRepository.getRunningWithProjects()
+    public func allProjectsWithStatus() throws -> [ProjectStatus] {
+        let projects = try projectRepository.list()
+        let runningSessions = try sessionRepository.getRunningWithProjects()
 
         let runningByProjectId = Dictionary(
             runningSessions.map { ($0.0.projectId, $0.0) },
@@ -36,8 +36,8 @@ public struct ReportService: Sendable {
 
     // MARK: - Time range reports
 
-    public func totals(from: Date, to: Date, projectId: Int? = nil) async throws -> ProjectTotals {
-        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
+    public func totals(from: Date, to: Date, projectId: Int? = nil) throws -> ProjectTotals {
+        let sessions = try sessionRepository.getSessions(from: from, to: to, projectId: projectId)
         let now = Date()
 
         var projectDurations: [String: TimeInterval] = [:]
@@ -68,24 +68,24 @@ public struct ReportService: Sendable {
         return ProjectTotals(entries: entries)
     }
 
-    public func groupedByDay(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
-        try await grouped(from: from, to: to, projectId: projectId, grouping: .day)
+    public func groupedByDay(from: Date, to: Date, projectId: Int? = nil) throws -> GroupedReport {
+        try grouped(from: from, to: to, projectId: projectId, grouping: .day)
     }
 
-    public func groupedByWeek(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
-        try await grouped(from: from, to: to, projectId: projectId, grouping: .week)
+    public func groupedByWeek(from: Date, to: Date, projectId: Int? = nil) throws -> GroupedReport {
+        try grouped(from: from, to: to, projectId: projectId, grouping: .week)
     }
 
-    public func groupedByWeekOfMonth(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
-        try await grouped(from: from, to: to, projectId: projectId, grouping: .weekOfMonth)
+    public func groupedByWeekOfMonth(from: Date, to: Date, projectId: Int? = nil) throws -> GroupedReport {
+        try grouped(from: from, to: to, projectId: projectId, grouping: .weekOfMonth)
     }
 
-    public func groupedByMonth(from: Date, to: Date, projectId: Int? = nil) async throws -> GroupedReport {
-        try await grouped(from: from, to: to, projectId: projectId, grouping: .month)
+    public func groupedByMonth(from: Date, to: Date, projectId: Int? = nil) throws -> GroupedReport {
+        try grouped(from: from, to: to, projectId: projectId, grouping: .month)
     }
 
-    private func grouped(from: Date, to: Date, projectId: Int? = nil, grouping: Grouping) async throws -> GroupedReport {
-        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
+    private func grouped(from: Date, to: Date, projectId: Int? = nil, grouping: Grouping) throws -> GroupedReport {
+        let sessions = try sessionRepository.getSessions(from: from, to: to, projectId: projectId)
         let now = Date()
         let calendar = Calendar.current
 
@@ -130,8 +130,8 @@ public struct ReportService: Sendable {
         return GroupedReport(columns: columns.map(\.label), rows: rows)
     }
 
-    public func verboseSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [VerboseSessionRow] {
-        let sessions = try await sessionRepository.getSessions(from: from, to: to, projectId: projectId)
+    public func verboseSessions(from: Date, to: Date, projectId: Int? = nil) throws -> [VerboseSessionRow] {
+        let sessions = try sessionRepository.getSessions(from: from, to: to, projectId: projectId)
 
         return sessions.map { session, project in
             VerboseSessionRow(

--- a/Sources/RockyCore/Services/SessionService.swift
+++ b/Sources/RockyCore/Services/SessionService.swift
@@ -7,40 +7,40 @@ public struct SessionService: Sendable {
         self.repository = repository
     }
 
-    public func start(projectId: Int) async throws {
-        try await repository.start(projectId: projectId)
+    public func start(projectId: Int) throws {
+        try repository.start(projectId: projectId)
     }
 
-    public func hasRunningSession(projectId: Int) async throws -> Bool {
-        try await repository.hasRunningSession(projectId: projectId)
+    public func hasRunningSession(projectId: Int) throws -> Bool {
+        try repository.hasRunningSession(projectId: projectId)
     }
 
-    public func stop(projectId: Int) async throws -> Session {
-        try await repository.stop(projectId: projectId)
+    public func stop(projectId: Int) throws -> Session {
+        try repository.stop(projectId: projectId)
     }
 
-    public func stopAll() async throws -> [Session] {
-        try await repository.stopAll()
+    public func stopAll() throws -> [Session] {
+        try repository.stopAll()
     }
 
-    public func getRunning() async throws -> [Session] {
-        try await repository.getRunning()
+    public func getRunning() throws -> [Session] {
+        try repository.getRunning()
     }
 
-    public func getRunningWithProjects() async throws -> [(Session, Project)] {
-        try await repository.getRunningWithProjects()
+    public func getRunningWithProjects() throws -> [(Session, Project)] {
+        try repository.getRunningWithProjects()
     }
 
-    public func insert(projectId: Int, startTime: Date, endTime: Date?) async throws {
-        try await repository.insert(projectId: projectId, startTime: startTime, endTime: endTime)
+    public func insert(projectId: Int, startTime: Date, endTime: Date?) throws {
+        try repository.insert(projectId: projectId, startTime: startTime, endTime: endTime)
     }
 
-    public func getSessions(from: Date, to: Date, projectId: Int? = nil) async throws -> [(Session, Project)] {
-        try await repository.getSessions(from: from, to: to, projectId: projectId)
+    public func getSessions(from: Date, to: Date, projectId: Int? = nil) throws -> [(Session, Project)] {
+        try repository.getSessions(from: from, to: to, projectId: projectId)
     }
 
-    public func getById(_ id: Int) async throws -> Session? {
-        try await repository.getById(id)
+    public func getById(_ id: Int) throws -> Session? {
+        try repository.getById(id)
     }
 
     public func editSession(
@@ -48,14 +48,14 @@ public struct SessionService: Sendable {
         newStart: Date?,
         newStop: Date?,
         newDuration: TimeInterval?
-    ) async throws -> Session {
+    ) throws -> Session {
         // Validate not overdetermined
         if newStart != nil && newStop != nil && newDuration != nil {
             throw RockyCoreError.overdetermined
         }
 
         // Fetch existing session
-        guard let existing = try await repository.getById(id) else {
+        guard let existing = try repository.getById(id) else {
             throw RockyCoreError.sessionNotFound(id)
         }
 
@@ -112,6 +112,6 @@ public struct SessionService: Sendable {
             throw RockyCoreError.stopBeforeStart
         }
 
-        return try await repository.update(id: id, startTime: finalStart, endTime: finalStop)
+        return try repository.update(id: id, startTime: finalStart, endTime: finalStop)
     }
 }

--- a/Tests/RockyCoreTests/DashboardServiceTests.swift
+++ b/Tests/RockyCoreTests/DashboardServiceTests.swift
@@ -18,10 +18,10 @@ struct DashboardServiceTests {
     }
 
     @Test("empty data returns zero stats")
-    func emptyStats() async throws {
+    func emptyStats() throws {
         let (_, _, service) = makeServices()
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.currentStreak == 0)
         #expect(data.stats.longestStreak == 0)
@@ -34,70 +34,70 @@ struct DashboardServiceTests {
     }
 
     @Test("totalHours sums all session durations")
-    func totalHours() async throws {
+    func totalHours() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // Two 2-hour sessions
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 9, hour: 10),
             endTime: date(day: 9, hour: 12)
         )
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 10, hour: 14),
             endTime: date(day: 10, hour: 16)
         )
 
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.totalHours == 4 * 3600)
     }
 
     @Test("sessionsThisWeek counts sessions overlapping current week")
-    func sessionsThisWeek() async throws {
+    func sessionsThisWeek() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // Week of Mar 9 (Monday) - Mar 11 is Wednesday
         // Session in this week
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 9, hour: 10),
             endTime: date(day: 9, hour: 12)
         )
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 10, hour: 10),
             endTime: date(day: 10, hour: 11)
         )
         // Session from last week (should not count)
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 6, hour: 10),
             endTime: date(day: 6, hour: 12)
         )
 
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.sessionsThisWeek == 2)
     }
 
     @Test("dailyAvgWeek divides week total by days elapsed")
-    func dailyAvgWeek() async throws {
+    func dailyAvgWeek() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // Mon Mar 9: 3 hours, Tue Mar 10: 3 hours = 6 hours over 2 days
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 9, hour: 9),
             endTime: date(day: 9, hour: 12)
         )
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 10, hour: 9),
             endTime: date(day: 10, hour: 12)
@@ -105,113 +105,113 @@ struct DashboardServiceTests {
 
         // Now is Wed Mar 11 at midnight = 2 days into week
         let now = date(day: 11, hour: 0)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         let expectedAvg = (6 * 3600.0) / 2.0
         #expect(abs(data.stats.dailyAvgWeek - expectedAvg) < 1)
     }
 
     @Test("topProject returns project with most all-time hours")
-    func topProject() async throws {
+    func topProject() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let p1 = try await projectRepo.findOrCreate(name: "Rocky")
-        let p2 = try await projectRepo.findOrCreate(name: "Other")
+        let p1 = try projectRepo.findOrCreate(name: "Rocky")
+        let p2 = try projectRepo.findOrCreate(name: "Other")
 
         // Rocky: 5 hours
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: p1.id,
             startTime: date(day: 9, hour: 8),
             endTime: date(day: 9, hour: 13)
         )
         // Other: 2 hours
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: p2.id,
             startTime: date(day: 9, hour: 14),
             endTime: date(day: 9, hour: 16)
         )
 
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.topProject == "Rocky")
     }
 
     @Test("bestDayThisWeek returns weekday with most hours")
-    func bestDayThisWeek() async throws {
+    func bestDayThisWeek() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // Mon Mar 9: 1 hour
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 9, hour: 10),
             endTime: date(day: 9, hour: 11)
         )
         // Tue Mar 10: 4 hours (should be best)
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: date(day: 10, hour: 8),
             endTime: date(day: 10, hour: 12)
         )
 
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         // Tuesday = weekday 3 in Calendar (1=Sun, 2=Mon, 3=Tue)
         #expect(data.stats.bestDayThisWeek == 3)
     }
 
     @Test("heatmap contains 31 weeks")
-    func heatmapWeekCount() async throws {
+    func heatmapWeekCount() throws {
         let (_, _, service) = makeServices()
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.heatmap.weeks.count == 31)
     }
 
     @Test("sparkline contains 31 data points")
-    func sparklinePointCount() async throws {
+    func sparklinePointCount() throws {
         let (_, _, service) = makeServices()
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.sparkline.values.count == 31)
     }
 
     @Test("running session included in sessionsThisWeek")
-    func runningSessionCountedInWeek() async throws {
+    func runningSessionCountedInWeek() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         let now = Date()
 
         // One completed session earlier today
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: now.addingTimeInterval(-7200),
             endTime: now.addingTimeInterval(-3600)
         )
         // One running session (nil end_time) started an hour ago
-        try await sessionRepo.insert(
+        try sessionRepo.insert(
             projectId: project.id,
             startTime: now.addingTimeInterval(-3600),
             endTime: nil
         )
 
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.sessionsThisWeek == 2)
     }
 
     @Test("streak calculation with consecutive days")
-    func streakCalculation() async throws {
+    func streakCalculation() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // 3 consecutive days: Mar 9, 10, 11
         for day in 9...11 {
-            try await sessionRepo.insert(
+            try sessionRepo.insert(
                 projectId: project.id,
                 startTime: date(day: day, hour: 10),
                 endTime: date(day: day, hour: 11)
@@ -219,7 +219,7 @@ struct DashboardServiceTests {
         }
 
         let now = date(day: 11, hour: 12)
-        let data = try await service.generate(now: now)
+        let data = try service.generate(now: now)
 
         #expect(data.stats.currentStreak == 3)
         #expect(data.stats.longestStreak == 3)

--- a/Tests/RockyCoreTests/MockRepositoryTests.swift
+++ b/Tests/RockyCoreTests/MockRepositoryTests.swift
@@ -7,82 +7,82 @@ import Foundation
 @Suite("MockProjectRepository")
 struct MockProjectRepositoryTests {
     @Test("findOrCreate creates a new project")
-    func createProject() async throws {
+    func createProject() throws {
         let repo = MockProjectRepository()
-        let project = try await repo.findOrCreate(name: "acme-corp")
+        let project = try repo.findOrCreate(name: "acme-corp")
         #expect(project.name == "acme-corp")
         #expect(project.id > 0)
         #expect(project.parentId == nil)
     }
 
     @Test("findOrCreate returns existing project on duplicate name")
-    func findExisting() async throws {
+    func findExisting() throws {
         let repo = MockProjectRepository()
-        let first = try await repo.findOrCreate(name: "acme-corp")
-        let second = try await repo.findOrCreate(name: "acme-corp")
+        let first = try repo.findOrCreate(name: "acme-corp")
+        let second = try repo.findOrCreate(name: "acme-corp")
         #expect(first.id == second.id)
     }
 
     @Test("getByName is case-insensitive")
-    func caseInsensitive() async throws {
+    func caseInsensitive() throws {
         let repo = MockProjectRepository()
-        _ = try await repo.findOrCreate(name: "Acme-Corp")
-        let found = try await repo.getByName("acme-corp")
+        _ = try repo.findOrCreate(name: "Acme-Corp")
+        let found = try repo.getByName("acme-corp")
         #expect(found != nil)
         #expect(found?.name == "Acme-Corp")
     }
 
     @Test("getByName returns nil for unknown project")
-    func unknownProject() async throws {
+    func unknownProject() throws {
         let repo = MockProjectRepository()
-        let found = try await repo.getByName("nonexistent")
+        let found = try repo.getByName("nonexistent")
         #expect(found == nil)
     }
 
     @Test("getById returns correct project")
-    func getById() async throws {
+    func getById() throws {
         let repo = MockProjectRepository()
-        let created = try await repo.findOrCreate(name: "test-project")
-        let found = try await repo.getById(created.id)
+        let created = try repo.findOrCreate(name: "test-project")
+        let found = try repo.getById(created.id)
         #expect(found != nil)
         #expect(found?.name == "test-project")
     }
 
     @Test("getById returns nil for unknown id")
-    func getByIdUnknown() async throws {
+    func getByIdUnknown() throws {
         let repo = MockProjectRepository()
-        let found = try await repo.getById(999)
+        let found = try repo.getById(999)
         #expect(found == nil)
     }
 
     @Test("list returns all projects")
-    func listProjects() async throws {
+    func listProjects() throws {
         let repo = MockProjectRepository()
-        _ = try await repo.findOrCreate(name: "alpha")
-        _ = try await repo.findOrCreate(name: "beta")
-        _ = try await repo.findOrCreate(name: "gamma")
-        let projects = try await repo.list()
+        _ = try repo.findOrCreate(name: "alpha")
+        _ = try repo.findOrCreate(name: "beta")
+        _ = try repo.findOrCreate(name: "gamma")
+        let projects = try repo.list()
         #expect(projects.count == 3)
     }
 
     @Test("findOrCreate deduplicates case-insensitively")
-    func findOrCreateCaseInsensitive() async throws {
+    func findOrCreateCaseInsensitive() throws {
         let repo = MockProjectRepository()
-        let first = try await repo.findOrCreate(name: "acme-corp")
-        let second = try await repo.findOrCreate(name: "ACME-CORP")
+        let first = try repo.findOrCreate(name: "acme-corp")
+        let second = try repo.findOrCreate(name: "ACME-CORP")
         #expect(first.id == second.id)
         #expect(second.name == "acme-corp")
-        let projects = try await repo.list()
+        let projects = try repo.list()
         #expect(projects.count == 1)
     }
 
     @Test("list returns projects in creation order")
-    func listOrder() async throws {
+    func listOrder() throws {
         let repo = MockProjectRepository()
-        _ = try await repo.findOrCreate(name: "charlie")
-        _ = try await repo.findOrCreate(name: "alpha")
-        _ = try await repo.findOrCreate(name: "bravo")
-        let projects = try await repo.list()
+        _ = try repo.findOrCreate(name: "charlie")
+        _ = try repo.findOrCreate(name: "alpha")
+        _ = try repo.findOrCreate(name: "bravo")
+        let projects = try repo.list()
         #expect(projects[0].name == "charlie")
         #expect(projects[1].name == "alpha")
         #expect(projects[2].name == "bravo")
@@ -94,213 +94,213 @@ struct MockProjectRepositoryTests {
 @Suite("MockSessionRepository")
 struct MockSessionRepositoryTests {
     @Test("start creates a running session")
-    func startSession() async throws {
+    func startSession() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        try await sessionRepo.start(projectId: project.id)
-        let running = try await sessionRepo.getRunning()
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        try sessionRepo.start(projectId: project.id)
+        let running = try sessionRepo.getRunning()
         #expect(running.count == 1)
         #expect(running[0].projectId == project.id)
         #expect(running[0].isRunning)
     }
 
     @Test("hasRunningSession returns false when nothing running")
-    func hasRunningFalse() async throws {
+    func hasRunningFalse() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        #expect(try await sessionRepo.hasRunningSession(projectId: project.id) == false)
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        #expect(try sessionRepo.hasRunningSession(projectId: project.id) == false)
     }
 
     @Test("hasRunningSession returns true after start")
-    func hasRunningTrue() async throws {
+    func hasRunningTrue() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        try await sessionRepo.start(projectId: project.id)
-        #expect(try await sessionRepo.hasRunningSession(projectId: project.id) == true)
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        try sessionRepo.start(projectId: project.id)
+        #expect(try sessionRepo.hasRunningSession(projectId: project.id) == true)
     }
 
     @Test("stop sets end_time on session")
-    func stopSession() async throws {
+    func stopSession() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        try await sessionRepo.start(projectId: project.id)
-        let stopped = try await sessionRepo.stop(projectId: project.id)
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        try sessionRepo.start(projectId: project.id)
+        let stopped = try sessionRepo.stop(projectId: project.id)
         #expect(stopped.endTime != nil)
         #expect(!stopped.isRunning)
-        let running = try await sessionRepo.getRunning()
+        let running = try sessionRepo.getRunning()
         #expect(running.isEmpty)
     }
 
     @Test("stop throws when no running session")
-    func stopNoRunning() async throws {
+    func stopNoRunning() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        await #expect(throws: RockyCoreError.self) {
-            try await sessionRepo.stop(projectId: project.id)
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        #expect(throws: RockyCoreError.self) {
+            try sessionRepo.stop(projectId: project.id)
         }
     }
 
     @Test("stopAll stops all running sessions")
-    func stopAll() async throws {
+    func stopAll() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let p1 = try await projectRepo.findOrCreate(name: "project-1")
-        let p2 = try await projectRepo.findOrCreate(name: "project-2")
-        try await sessionRepo.start(projectId: p1.id)
-        try await sessionRepo.start(projectId: p2.id)
-        let stopped = try await sessionRepo.stopAll()
+        let p1 = try projectRepo.findOrCreate(name: "project-1")
+        let p2 = try projectRepo.findOrCreate(name: "project-2")
+        try sessionRepo.start(projectId: p1.id)
+        try sessionRepo.start(projectId: p2.id)
+        let stopped = try sessionRepo.stopAll()
         #expect(stopped.count == 2)
         #expect(stopped.allSatisfy { !$0.isRunning })
-        let running = try await sessionRepo.getRunning()
+        let running = try sessionRepo.getRunning()
         #expect(running.isEmpty)
     }
 
     @Test("stopAll returns empty array when nothing running")
-    func stopAllEmpty() async throws {
+    func stopAllEmpty() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let stopped = try await sessionRepo.stopAll()
+        let stopped = try sessionRepo.stopAll()
         #expect(stopped.isEmpty)
     }
 
     @Test("concurrent timers on different projects")
-    func concurrentTimers() async throws {
+    func concurrentTimers() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let p1 = try await projectRepo.findOrCreate(name: "project-1")
-        let p2 = try await projectRepo.findOrCreate(name: "project-2")
-        try await sessionRepo.start(projectId: p1.id)
-        try await sessionRepo.start(projectId: p2.id)
-        let running = try await sessionRepo.getRunning()
+        let p1 = try projectRepo.findOrCreate(name: "project-1")
+        let p2 = try projectRepo.findOrCreate(name: "project-2")
+        try sessionRepo.start(projectId: p1.id)
+        try sessionRepo.start(projectId: p2.id)
+        let running = try sessionRepo.getRunning()
         #expect(running.count == 2)
     }
 
     @Test("stop one timer leaves other running")
-    func stopOneOfTwo() async throws {
+    func stopOneOfTwo() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let p1 = try await projectRepo.findOrCreate(name: "project-1")
-        let p2 = try await projectRepo.findOrCreate(name: "project-2")
-        try await sessionRepo.start(projectId: p1.id)
-        try await sessionRepo.start(projectId: p2.id)
-        _ = try await sessionRepo.stop(projectId: p1.id)
-        let running = try await sessionRepo.getRunning()
+        let p1 = try projectRepo.findOrCreate(name: "project-1")
+        let p2 = try projectRepo.findOrCreate(name: "project-2")
+        try sessionRepo.start(projectId: p1.id)
+        try sessionRepo.start(projectId: p2.id)
+        _ = try sessionRepo.stop(projectId: p1.id)
+        let running = try sessionRepo.getRunning()
         #expect(running.count == 1)
         #expect(running[0].projectId == p2.id)
     }
 
     @Test("getRunningWithProjects returns session and project data")
-    func runningWithProjects() async throws {
+    func runningWithProjects() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "acme-corp")
-        try await sessionRepo.start(projectId: project.id)
-        let running = try await sessionRepo.getRunningWithProjects()
+        let project = try projectRepo.findOrCreate(name: "acme-corp")
+        try sessionRepo.start(projectId: project.id)
+        let running = try sessionRepo.getRunningWithProjects()
         #expect(running.count == 1)
         #expect(running[0].0.projectId == project.id)
         #expect(running[0].1.name == "acme-corp")
     }
 
     @Test("insert creates session with explicit start/end times")
-    func insertSession() async throws {
+    func insertSession() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
         let start = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
         let end = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
-        try await sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
+        try sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessionRepo.getSessions(from: from, to: to)
+        let results = try sessionRepo.getSessions(from: from, to: to)
         #expect(results.count == 1)
         #expect(results[0].0.startTime == start)
         #expect(results[0].0.endTime == end)
     }
 
     @Test("getSessions returns sessions overlapping date range")
-    func getSessionsDateRange() async throws {
+    func getSessionsDateRange() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
         // Fully inside range
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
         // Fully outside range (day before)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 11))!)
         // Spanning into range
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 23))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 1))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessionRepo.getSessions(from: from, to: to)
+        let results = try sessionRepo.getSessions(from: from, to: to)
 
         #expect(results.count == 2)
     }
 
     @Test("getSessions excludes sessions outside the range")
-    func getSessionsOutsideRange() async throws {
+    func getSessionsOutsideRange() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 11))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessionRepo.getSessions(from: from, to: to)
+        let results = try sessionRepo.getSessions(from: from, to: to)
 
         #expect(results.isEmpty)
     }
 
     @Test("stopAll only affects running sessions")
-    func stopAllLeavesStoppedAlone() async throws {
+    func stopAllLeavesStoppedAlone() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let p1 = try await projectRepo.findOrCreate(name: "already-stopped")
-        let p2 = try await projectRepo.findOrCreate(name: "still-running")
-        try await sessionRepo.start(projectId: p1.id)
-        _ = try await sessionRepo.stop(projectId: p1.id)
-        try await sessionRepo.start(projectId: p2.id)
-        let stopped = try await sessionRepo.stopAll()
+        let p1 = try projectRepo.findOrCreate(name: "already-stopped")
+        let p2 = try projectRepo.findOrCreate(name: "still-running")
+        try sessionRepo.start(projectId: p1.id)
+        _ = try sessionRepo.stop(projectId: p1.id)
+        try sessionRepo.start(projectId: p2.id)
+        let stopped = try sessionRepo.stopAll()
         #expect(stopped.count == 1)
         #expect(stopped[0].projectId == p2.id)
     }
 
     @Test("getSessions filters by projectId")
-    func getSessionsFilterByProject() async throws {
+    func getSessionsFilterByProject() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
         let cal = Calendar.current
-        let p1 = try await projectRepo.findOrCreate(name: "included")
-        let p2 = try await projectRepo.findOrCreate(name: "excluded")
+        let p1 = try projectRepo.findOrCreate(name: "included")
+        let p2 = try projectRepo.findOrCreate(name: "excluded")
 
-        try await sessionRepo.insert(projectId: p1.id,
+        try sessionRepo.insert(projectId: p1.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
-        try await sessionRepo.insert(projectId: p2.id,
+        try sessionRepo.insert(projectId: p2.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessionRepo.getSessions(from: from, to: to, projectId: p1.id)
+        let results = try sessionRepo.getSessions(from: from, to: to, projectId: p1.id)
 
         #expect(results.count == 1)
         #expect(results[0].1.name == "included")
@@ -312,43 +312,43 @@ struct MockSessionRepositoryTests {
 @Suite("MockSessionRepository Edit")
 struct MockSessionEditTests {
     @Test("getById returns correct session")
-    func getById() async throws {
+    func getById() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
         let cal = Calendar.current
         let start = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
         let end = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
-        try await sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
+        try sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
 
-        let sessions = try await sessionRepo.getSessions(
+        let sessions = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
-        let session = try await sessionRepo.getById(sessions[0].0.id)
+        let session = try sessionRepo.getById(sessions[0].0.id)
         #expect(session != nil)
         #expect(session?.startTime == start)
     }
 
     @Test("getById returns nil for unknown id")
-    func getByIdUnknown() async throws {
+    func getByIdUnknown() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let session = try await sessionRepo.getById(999)
+        let session = try sessionRepo.getById(999)
         #expect(session == nil)
     }
 
     @Test("update modifies session times")
-    func update() async throws {
+    func update() throws {
         let projectRepo = MockProjectRepository()
         let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
         let cal = Calendar.current
         let start = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
         let end = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
-        try await sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
+        try sessionRepo.insert(projectId: project.id, startTime: start, endTime: end)
 
-        let sessions = try await sessionRepo.getSessions(
+        let sessions = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -356,12 +356,12 @@ struct MockSessionEditTests {
 
         let newStart = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
         let newEnd = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 12))!
-        let updated = try await sessionRepo.update(id: sessionId, startTime: newStart, endTime: newEnd)
+        let updated = try sessionRepo.update(id: sessionId, startTime: newStart, endTime: newEnd)
 
         #expect(updated.startTime == newStart)
         #expect(updated.endTime == newEnd)
 
-        let fetched = try await sessionRepo.getById(sessionId)
+        let fetched = try sessionRepo.getById(sessionId)
         #expect(fetched?.startTime == newStart)
         #expect(fetched?.endTime == newEnd)
     }

--- a/Tests/RockyCoreTests/ReportServiceTests.swift
+++ b/Tests/RockyCoreTests/ReportServiceTests.swift
@@ -12,32 +12,32 @@ struct ReportServiceTests {
     }
 
     @Test("allProjectsWithStatus returns empty for no projects")
-    func statusEmpty() async throws {
+    func statusEmpty() throws {
         let (_, _, reportService) = makeServices()
-        let statuses = try await reportService.allProjectsWithStatus()
+        let statuses = try reportService.allProjectsWithStatus()
         #expect(statuses.isEmpty)
     }
 
     @Test("allProjectsWithStatus shows idle projects with no sessions")
-    func statusNoSessions() async throws {
+    func statusNoSessions() throws {
         let (projectRepo, _, reportService) = makeServices()
-        _ = try await projectRepo.findOrCreate(name: "idle-project")
-        let statuses = try await reportService.allProjectsWithStatus()
+        _ = try projectRepo.findOrCreate(name: "idle-project")
+        let statuses = try reportService.allProjectsWithStatus()
         #expect(statuses.count == 1)
         #expect(!statuses[0].isRunning)
         #expect(statuses[0].runningSession == nil)
     }
 
     @Test("allProjectsWithStatus shows running projects first")
-    func statusOrder() async throws {
+    func statusOrder() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
-        let p1 = try await projectRepo.findOrCreate(name: "inactive")
-        let p2 = try await projectRepo.findOrCreate(name: "active")
-        try await sessionRepo.start(projectId: p1.id)
-        _ = try await sessionRepo.stop(projectId: p1.id)
-        try await sessionRepo.start(projectId: p2.id)
+        let p1 = try projectRepo.findOrCreate(name: "inactive")
+        let p2 = try projectRepo.findOrCreate(name: "active")
+        try sessionRepo.start(projectId: p1.id)
+        _ = try sessionRepo.stop(projectId: p1.id)
+        try sessionRepo.start(projectId: p2.id)
 
-        let statuses = try await reportService.allProjectsWithStatus()
+        let statuses = try reportService.allProjectsWithStatus()
         #expect(statuses.count == 2)
         #expect(statuses[0].project.name == "active")
         #expect(statuses[0].isRunning)
@@ -46,132 +46,132 @@ struct ReportServiceTests {
     }
 
     @Test("totals calculates project durations in range")
-    func totals() async throws {
+    func totals() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
 
-        let result = try await reportService.totals(from: from, to: to)
+        let result = try reportService.totals(from: from, to: to)
         #expect(result.entries.count == 1)
         #expect(result.entries[0].projectName == "test")
         #expect(abs(result.entries[0].duration - 3600) < 1)
     }
 
     @Test("totals filters by project")
-    func totalsFiltered() async throws {
+    func totalsFiltered() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let p1 = try await projectRepo.findOrCreate(name: "included")
-        let p2 = try await projectRepo.findOrCreate(name: "excluded")
+        let p1 = try projectRepo.findOrCreate(name: "included")
+        let p2 = try projectRepo.findOrCreate(name: "excluded")
 
-        try await sessionRepo.insert(projectId: p1.id,
+        try sessionRepo.insert(projectId: p1.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
-        try await sessionRepo.insert(projectId: p2.id,
+        try sessionRepo.insert(projectId: p2.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
 
-        let result = try await reportService.totals(from: from, to: to, projectId: p1.id)
+        let result = try reportService.totals(from: from, to: to, projectId: p1.id)
         #expect(result.entries.count == 1)
         #expect(result.entries[0].projectName == "included")
     }
 
     @Test("totals sums multiple sessions for same project")
-    func totalsSumMultiple() async throws {
+    func totalsSumMultiple() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
 
-        let result = try await reportService.totals(from: from, to: to)
+        let result = try reportService.totals(from: from, to: to)
         #expect(result.entries.count == 1)
         #expect(abs(result.entries[0].duration - 7200) < 1)
     }
 
     @Test("totals returns empty entries for range with no sessions")
-    func totalsEmpty() async throws {
+    func totalsEmpty() throws {
         let (_, _, reportService) = makeServices()
         let cal = Calendar.current
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let result = try await reportService.totals(from: from, to: to)
+        let result = try reportService.totals(from: from, to: to)
         #expect(result.entries.isEmpty)
         #expect(result.total == 0)
     }
 
     @Test("totals includes running session duration up to range end")
-    func totalsRunningSession() async throws {
+    func totalsRunningSession() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "running")
+        let project = try projectRepo.findOrCreate(name: "running")
 
         // Insert a running session (no endTime) that started 2 hours ago
         let startTime = Date().addingTimeInterval(-7200)
-        try await sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: nil)
+        try sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: nil)
 
         let from = cal.startOfDay(for: Date())
         let to = cal.date(byAdding: .day, value: 1, to: from)!
 
-        let result = try await reportService.totals(from: from, to: to)
+        let result = try reportService.totals(from: from, to: to)
         #expect(result.entries.count == 1)
         #expect(result.entries[0].isRunning)
         #expect(result.entries[0].duration > 0)
     }
 
     @Test("totals clamps sessions that partially overlap the range")
-    func partialOverlap() async throws {
+    func partialOverlap() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 5, hour: 22))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 2))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
 
-        let result = try await reportService.totals(from: from, to: to)
+        let result = try reportService.totals(from: from, to: to)
         #expect(result.entries.count == 1)
         #expect(abs(result.entries[0].duration - 7200) < 1)
     }
 
     @Test("groupedByDay distributes sessions across correct days")
-    func groupedByDay() async throws {
+    func groupedByDay() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 12))!)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 9))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 4, hour: 10))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 8))!
 
-        let report = try await reportService.groupedByDay(from: from, to: to)
+        let report = try reportService.groupedByDay(from: from, to: to)
         #expect(report.columns.count == 6)
         #expect(report.rows.count == 1)
         #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
@@ -180,63 +180,63 @@ struct ReportServiceTests {
     }
 
     @Test("session spanning midnight splits across days")
-    func sessionSpanningMidnight() async throws {
+    func sessionSpanningMidnight() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "late-night")
+        let project = try projectRepo.findOrCreate(name: "late-night")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 23))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 3, hour: 1))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 4))!
 
-        let report = try await reportService.groupedByDay(from: from, to: to)
+        let report = try reportService.groupedByDay(from: from, to: to)
         #expect(report.columns.count == 2)
         #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 3600) < 1)
         #expect(abs((report.rows[0].columnDurations[1] ?? 0) - 3600) < 1)
     }
 
     @Test("groupedByWeek creates correct week columns")
-    func groupedByWeek() async throws {
+    func groupedByWeek() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 11))!)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 11))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 15))!
 
-        let report = try await reportService.groupedByWeek(from: from, to: to)
+        let report = try reportService.groupedByWeek(from: from, to: to)
         #expect(report.rows.count == 1)
         #expect(report.columns.count >= 2)
         #expect(abs(report.grandTotal - 7200) < 1)
     }
 
     @Test("groupedByMonth creates correct month columns")
-    func groupedByMonth() async throws {
+    func groupedByMonth() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 1, day: 15, hour: 12))!)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 9))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 10))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 1, day: 1))!
         let to = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
 
-        let report = try await reportService.groupedByMonth(from: from, to: to)
+        let report = try reportService.groupedByMonth(from: from, to: to)
         #expect(report.columns.count == 3)
         #expect(report.rows.count == 1)
         #expect(abs((report.rows[0].columnDurations[0] ?? 0) - 7200) < 1)
@@ -245,22 +245,22 @@ struct ReportServiceTests {
     }
 
     @Test("verboseSessions returns individual session rows")
-    func verboseSessions() async throws {
+    func verboseSessions() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "test")
+        let project = try projectRepo.findOrCreate(name: "test")
 
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 8))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!)
-        try await sessionRepo.insert(projectId: project.id,
+        try sessionRepo.insert(projectId: project.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 15))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
 
-        let rows = try await reportService.verboseSessions(from: from, to: to)
+        let rows = try reportService.verboseSessions(from: from, to: to)
         #expect(rows.count == 2)
         #expect(rows[0].projectName == "test")
         #expect(rows[1].projectName == "test")
@@ -268,23 +268,23 @@ struct ReportServiceTests {
     }
 
     @Test("multiple projects sorted by total duration, running first")
-    func multipleProjectsGrouped() async throws {
+    func multipleProjectsGrouped() throws {
         let (projectRepo, sessionRepo, reportService) = makeServices()
         let cal = Calendar.current
-        let p1 = try await projectRepo.findOrCreate(name: "alpha")
-        let p2 = try await projectRepo.findOrCreate(name: "beta")
+        let p1 = try projectRepo.findOrCreate(name: "alpha")
+        let p2 = try projectRepo.findOrCreate(name: "beta")
 
-        try await sessionRepo.insert(projectId: p1.id,
+        try sessionRepo.insert(projectId: p1.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 13))!)
-        try await sessionRepo.insert(projectId: p2.id,
+        try sessionRepo.insert(projectId: p2.id,
             startTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!,
             endTime: cal.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 10))!)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 3))!
 
-        let report = try await reportService.groupedByDay(from: from, to: to)
+        let report = try reportService.groupedByDay(from: from, to: to)
         #expect(report.rows.count == 2)
         #expect(report.rows[0].projectName == "alpha")
         #expect(report.rows[1].projectName == "beta")

--- a/Tests/RockyCoreTests/SQLiteIntegrationTests.swift
+++ b/Tests/RockyCoreTests/SQLiteIntegrationTests.swift
@@ -2,33 +2,17 @@ import Testing
 import Foundation
 @testable import RockyCore
 
-actor TestDatabase {
-    static let shared = TestDatabase()
-    private var db: Database?
-
-    func get() throws -> Database {
-        if let db { return db }
-        let db = try Database.inMemory()
-        self.db = db
-        return db
-    }
-
-    func reset() async throws {
-        let db = try get()
-        try await db.dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM sessions")
-            try db.execute(sql: "DELETE FROM projects")
-        }
-    }
+private func makeTestDatabase() throws -> Database {
+    try Database.inMemory()
 }
 
 @Suite("SQLite Integration", .serialized)
 struct SQLiteIntegrationTests {
 
     @Test("Tables exist after migration")
-    func tablesExist() async throws {
-        let db = try await TestDatabase.shared.get()
-        let tables = try await db.dbQueue.read { db in
+    func tablesExist() throws {
+        let db = try makeTestDatabase()
+        let tables = try db.dbQueue.read { db in
             try String.fetchAll(db, sql:
                 "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
         }
@@ -37,9 +21,9 @@ struct SQLiteIntegrationTests {
     }
 
     @Test("GRDB migrations table exists")
-    func grdbMigrationsExist() async throws {
-        let db = try await TestDatabase.shared.get()
-        let tables = try await db.dbQueue.read { db in
+    func grdbMigrationsExist() throws {
+        let db = try makeTestDatabase()
+        let tables = try db.dbQueue.read { db in
             try String.fetchAll(db, sql:
                 "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'grdb%'")
         }
@@ -47,10 +31,10 @@ struct SQLiteIntegrationTests {
     }
 
     @Test("Migrations are idempotent")
-    func migrationsIdempotent() async throws {
-        let db = try await TestDatabase.shared.get()
+    func migrationsIdempotent() throws {
+        let db = try makeTestDatabase()
         try Migrations.run(on: db)
-        let tables = try await db.dbQueue.read { db in
+        let tables = try db.dbQueue.read { db in
             try String.fetchAll(db, sql:
                 "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
         }
@@ -59,33 +43,31 @@ struct SQLiteIntegrationTests {
     }
 
     @Test("SQLiteProjectRepository round-trips project data")
-    func projectRoundTrip() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
+    func projectRoundTrip() throws {
+        let db = try makeTestDatabase()
         let repo = SQLiteProjectRepository(db: db)
-        let created = try await repo.findOrCreate(name: "round-trip-test")
-        let found = try await repo.getById(created.id)
+        let created = try repo.findOrCreate(name: "round-trip-test")
+        let found = try repo.getById(created.id)
         #expect(found != nil)
         #expect(found?.name == "round-trip-test")
         #expect(found?.id == created.id)
     }
 
     @Test("SQLiteSessionRepository round-trips session data")
-    func sessionRoundTrip() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
+    func sessionRoundTrip() throws {
+        let db = try makeTestDatabase()
         let projectRepo = SQLiteProjectRepository(db: db)
         let sessionRepo = SQLiteSessionRepository(db: db)
         let cal = Calendar.current
-        let project = try await projectRepo.findOrCreate(name: "round-trip-test")
+        let project = try projectRepo.findOrCreate(name: "round-trip-test")
 
         let startTime = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 10))!
         let endTime = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
-        try await sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: endTime)
+        try sessionRepo.insert(projectId: project.id, startTime: startTime, endTime: endTime)
 
         let from = cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!
         let to = cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
-        let results = try await sessionRepo.getSessions(from: from, to: to)
+        let results = try sessionRepo.getSessions(from: from, to: to)
 
         #expect(results.count == 1)
         #expect(abs(results[0].0.startTime.timeIntervalSince(startTime)) < 1)
@@ -93,45 +75,42 @@ struct SQLiteIntegrationTests {
     }
 
     @Test("SQLite start and stop round-trip")
-    func startStopRoundTrip() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
+    func startStopRoundTrip() throws {
+        let db = try makeTestDatabase()
         let projectRepo = SQLiteProjectRepository(db: db)
         let sessionRepo = SQLiteSessionRepository(db: db)
-        let project = try await projectRepo.findOrCreate(name: "start-stop-test")
-        try await sessionRepo.start(projectId: project.id)
+        let project = try projectRepo.findOrCreate(name: "start-stop-test")
+        try sessionRepo.start(projectId: project.id)
 
-        let running = try await sessionRepo.getRunning()
+        let running = try sessionRepo.getRunning()
         #expect(running.count == 1)
         #expect(running[0].isRunning)
 
-        let stopped = try await sessionRepo.stop(projectId: project.id)
+        let stopped = try sessionRepo.stop(projectId: project.id)
         #expect(!stopped.isRunning)
         #expect(stopped.endTime != nil)
 
-        let afterStop = try await sessionRepo.getRunning()
+        let afterStop = try sessionRepo.getRunning()
         #expect(afterStop.isEmpty)
     }
 
     @Test("SQLite findOrCreate deduplicates case-insensitively")
-    func findOrCreateCaseInsensitiveSQLite() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
+    func findOrCreateCaseInsensitiveSQLite() throws {
+        let db = try makeTestDatabase()
         let repo = SQLiteProjectRepository(db: db)
-        let first = try await repo.findOrCreate(name: "acme-corp")
-        let second = try await repo.findOrCreate(name: "ACME-CORP")
+        let first = try repo.findOrCreate(name: "acme-corp")
+        let second = try repo.findOrCreate(name: "ACME-CORP")
         #expect(first.id == second.id)
-        let projects = try await repo.list()
+        let projects = try repo.list()
         #expect(projects.count == 1)
     }
 
     @Test("Case-insensitive project lookup works in SQLite")
-    func caseInsensitiveSQLite() async throws {
-        try await TestDatabase.shared.reset()
-        let db = try await TestDatabase.shared.get()
+    func caseInsensitiveSQLite() throws {
+        let db = try makeTestDatabase()
         let repo = SQLiteProjectRepository(db: db)
-        _ = try await repo.findOrCreate(name: "MyProject")
-        let found = try await repo.getByName("myproject")
+        _ = try repo.findOrCreate(name: "MyProject")
+        let found = try repo.getByName("myproject")
         #expect(found != nil)
         #expect(found?.name == "MyProject")
     }

--- a/Tests/RockyCoreTests/SessionEditTests.swift
+++ b/Tests/RockyCoreTests/SessionEditTests.swift
@@ -18,19 +18,19 @@ struct SessionEditTests {
         projectId: Int,
         startHour: Int, startDay: Int = 6,
         endHour: Int, endDay: Int = 6
-    ) async throws {
+    ) throws {
         let start = cal.date(from: DateComponents(year: 2026, month: 3, day: startDay, hour: startHour))!
         let end = cal.date(from: DateComponents(year: 2026, month: 3, day: endDay, hour: endHour))!
-        try await sessionRepo.insert(projectId: projectId, startTime: start, endTime: end)
+        try sessionRepo.insert(projectId: projectId, startTime: start, endTime: end)
     }
 
     @Test("edit with --start only updates start, keeps stop")
-    func editStartOnly() async throws {
+    func editStartOnly() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -38,19 +38,19 @@ struct SessionEditTests {
         let originalEnd = all[0].0.endTime!
 
         let newStart = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
-        let updated = try await service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
+        let updated = try service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
 
         #expect(updated.startTime == newStart)
         #expect(updated.endTime == originalEnd)
     }
 
     @Test("edit with --stop only updates stop, keeps start")
-    func editStopOnly() async throws {
+    func editStopOnly() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -58,19 +58,19 @@ struct SessionEditTests {
         let originalStart = all[0].0.startTime
 
         let newStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!
-        let updated = try await service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
+        let updated = try service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
 
         #expect(updated.startTime == originalStart)
         #expect(updated.endTime == newStop)
     }
 
     @Test("edit with --start + --stop updates both")
-    func editStartAndStop() async throws {
+    func editStartAndStop() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -78,76 +78,76 @@ struct SessionEditTests {
 
         let newStart = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
         let newStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
-        let updated = try await service.editSession(id: sessionId, newStart: newStart, newStop: newStop, newDuration: nil)
+        let updated = try service.editSession(id: sessionId, newStart: newStart, newStop: newStop, newDuration: nil)
 
         #expect(updated.startTime == newStart)
         #expect(updated.endTime == newStop)
     }
 
     @Test("edit with --duration only keeps start, computes stop")
-    func editDurationOnly() async throws {
+    func editDurationOnly() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
         let originalStart = all[0].0.startTime
 
-        let updated = try await service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: 3600)
+        let updated = try service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: 3600)
 
         #expect(updated.startTime == originalStart)
         #expect(abs(updated.endTime!.timeIntervalSince(originalStart) - 3600) < 1)
     }
 
     @Test("edit with --start + --duration sets start and computes stop")
-    func editStartAndDuration() async throws {
+    func editStartAndDuration() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
 
         let newStart = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
-        let updated = try await service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: 5400)
+        let updated = try service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: 5400)
 
         #expect(updated.startTime == newStart)
         #expect(abs(updated.endTime!.timeIntervalSince(newStart) - 5400) < 1)
     }
 
     @Test("edit with --stop + --duration sets stop and computes start")
-    func editStopAndDuration() async throws {
+    func editStopAndDuration() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
 
         let newStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 14))!
-        let updated = try await service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: 7200)
+        let updated = try service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: 7200)
 
         #expect(abs(updated.startTime.timeIntervalSince(newStop) + 7200) < 1)
         #expect(updated.endTime == newStop)
     }
 
     @Test("edit with all three flags throws overdetermined")
-    func editOverdetermined() async throws {
+    func editOverdetermined() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -156,41 +156,41 @@ struct SessionEditTests {
         let newStart = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
         let newStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 11))!
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: newStart, newStop: newStop, newDuration: 3600)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: newStart, newStop: newStop, newDuration: 3600)
         }
     }
 
     @Test("edit non-existent session throws sessionNotFound")
-    func editNotFound() async throws {
+    func editNotFound() throws {
         let (_, _, service) = makeServices()
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: 999, newStart: Date(), newStop: nil, newDuration: nil)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: 999, newStart: Date(), newStop: nil, newDuration: nil)
         }
     }
 
     @Test("edit stop of running session throws cannotEditRunningSessionStop")
-    func editRunningStop() async throws {
+    func editRunningStop() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await sessionRepo.start(projectId: project.id)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try sessionRepo.start(projectId: project.id)
 
-        let running = try await sessionRepo.getRunning()
+        let running = try sessionRepo.getRunning()
         let sessionId = running[0].id
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: nil, newStop: Date(), newDuration: nil)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: nil, newStop: Date(), newDuration: nil)
         }
     }
 
     @Test("edit start in future throws startTimeInFuture")
-    func editFutureStart() async throws {
+    func editFutureStart() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -198,18 +198,18 @@ struct SessionEditTests {
 
         let futureStart = Date().addingTimeInterval(86400)
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: futureStart, newStop: nil, newDuration: nil)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: futureStart, newStop: nil, newDuration: nil)
         }
     }
 
     @Test("edit with stop before start throws stopBeforeStart")
-    func editStopBeforeStart() async throws {
+    func editStopBeforeStart() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
@@ -217,75 +217,75 @@ struct SessionEditTests {
 
         let badStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: nil, newStop: badStop, newDuration: nil)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: nil, newStop: badStop, newDuration: nil)
         }
     }
 
     @Test("edit with zero duration throws durationNotPositive")
-    func editZeroDuration() async throws {
+    func editZeroDuration() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: 0)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: 0)
         }
     }
 
     @Test("edit with negative duration throws durationNotPositive")
-    func editNegativeDuration() async throws {
+    func editNegativeDuration() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 10, endHour: 12)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 6))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
 
-        await #expect(throws: RockyCoreError.self) {
-            try await service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: -100)
+        #expect(throws: RockyCoreError.self) {
+            try service.editSession(id: sessionId, newStart: nil, newStop: nil, newDuration: -100)
         }
     }
 
     @Test("edit start of running session is allowed")
-    func editRunningStart() async throws {
+    func editRunningStart() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await sessionRepo.start(projectId: project.id)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try sessionRepo.start(projectId: project.id)
 
-        let running = try await sessionRepo.getRunning()
+        let running = try sessionRepo.getRunning()
         let sessionId = running[0].id
 
         let newStart = Date().addingTimeInterval(-7200)
-        let updated = try await service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
+        let updated = try service.editSession(id: sessionId, newStart: newStart, newStop: nil, newDuration: nil)
 
         #expect(abs(updated.startTime.timeIntervalSince(newStart)) < 1)
         #expect(updated.isRunning)
     }
 
     @Test("edit session spanning midnight")
-    func editMidnightSession() async throws {
+    func editMidnightSession() throws {
         let (projectRepo, sessionRepo, service) = makeServices()
-        let project = try await projectRepo.findOrCreate(name: "test")
-        try await insertSession(sessionRepo, projectId: project.id, startHour: 23, startDay: 5, endHour: 10, endDay: 6)
+        let project = try projectRepo.findOrCreate(name: "test")
+        try insertSession(sessionRepo, projectId: project.id, startHour: 23, startDay: 5, endHour: 10, endDay: 6)
 
-        let all = try await sessionRepo.getSessions(
+        let all = try sessionRepo.getSessions(
             from: cal.date(from: DateComponents(year: 2026, month: 3, day: 5))!,
             to: cal.date(from: DateComponents(year: 2026, month: 3, day: 7))!
         )
         let sessionId = all[0].0.id
 
         let newStop = cal.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 1, minute: 30))!
-        let updated = try await service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
+        let updated = try service.editSession(id: sessionId, newStart: nil, newStop: newStop, newDuration: nil)
 
         #expect(updated.endTime == newStop)
         #expect(updated.duration() == 9000) // 2.5 hours


### PR DESCRIPTION
## Summary

Closes #89

Remove async/await from the entire stack — 23 files changed:

- **Repository protocols**: `async throws` → `throws`
- **SQLite repositories**: remove `await` from `dbQueue.read/write`
- **Mock repositories**: remove `async` from protocol conformance
- **Services**: all methods `async throws` → `throws`
- **CLI commands**: `AsyncParsableCommand` → `ParsableCommand`, `run() async throws` → `run() throws`
- **AppContext**: `build() async throws` → `build() throws`
- **Rocky.swift**: `AsyncParsableCommand` → `ParsableCommand`
- **Tests**: remove `async`/`await` from all test functions, replace `TestDatabase` actor with simple function

## Why

GRDB is synchronous. async/await was only present because sqlite-nio required NIO infrastructure. Keeping async on purely synchronous code is misleading.

## Test plan

- [x] All 133 tests pass
- [x] `swift build` succeeds
- [x] Zero `async`/`await` remaining in Sources/ and Tests/