### PR TITLE
Add CommandResult type and text OutputFormatter

### DIFF
--- a/Sources/App/Output/CommandResult.swift
+++ b/Sources/App/Output/CommandResult.swift
@@ -7,16 +7,16 @@ struct StopEntry {
 }
 
 enum CommandResult {
-    // Sessions
-    case started(project: String, running: [String])
-    case stopped(entries: [StopEntry])
-    case status(statuses: [ProjectStatus])
-    case todayTotals(totals: ProjectTotals, period: String)
-    case grouped(report: GroupedReport, period: String, projectFilter: String?, hoursOnly: Bool)
-    case verbose(sessions: [VerboseSessionRow], period: String, projectFilter: String?)
-    case edited(session: Session)
+    // Session
+    case sessionStarted(project: String, running: [String])
+    case sessionStopped(entries: [StopEntry])
+    case sessionStatus(statuses: [ProjectStatus])
+    case sessionTodayTotals(totals: ProjectTotals, period: String)
+    case sessionGrouped(report: GroupedReport, period: String, projectFilter: String?, hoursOnly: Bool)
+    case sessionVerbose(sessions: [VerboseSessionRow], period: String, projectFilter: String?)
+    case sessionEdited(session: Session)
 
-    // Projects
+    // Project
     case projectList(projects: [Project])
     case projectRenamed(oldName: String, newName: String)
 

--- a/Sources/App/Output/OutputFormatter.swift
+++ b/Sources/App/Output/OutputFormatter.swift
@@ -5,14 +5,14 @@ enum OutputFormatter {
 
     static func formatText(_ result: CommandResult) -> String {
         switch result {
-        case .started(let project, let running):
+        case .sessionStarted(let project, let running):
             var msg = "Started \(project)"
             if !running.isEmpty {
                 msg += "\nCurrently running: \(running.joined(separator: ", "))"
             }
             return msg
 
-        case .stopped(let entries):
+        case .sessionStopped(let entries):
             if entries.isEmpty {
                 return "No timers currently running."
             }
@@ -26,19 +26,19 @@ enum OutputFormatter {
                 return "Stopped \(padded)  (\(DurationFormat.formatted(entry.duration)))"
             }.joined(separator: "\n")
 
-        case .status(let statuses):
+        case .sessionStatus(let statuses):
             return Table.renderStatus(statuses)
 
-        case .todayTotals(let totals, let period):
+        case .sessionTodayTotals(let totals, let period):
             return Table.renderTodayTotals(totals, period: period)
 
-        case .grouped(let report, let period, let projectFilter, let hoursOnly):
+        case .sessionGrouped(let report, let period, let projectFilter, let hoursOnly):
             return Table.renderGrouped(report, period: period, projectFilter: projectFilter, hoursOnly: hoursOnly)
 
-        case .verbose(let sessions, let period, let projectFilter):
+        case .sessionVerbose(let sessions, let period, let projectFilter):
             return Table.renderVerbose(sessions, period: period, projectFilter: projectFilter)
 
-        case .edited(let session):
+        case .sessionEdited(let session):
             let startStr = session.startTime.formatted(DateTimeFormat.time)
             let stopStr = session.isRunning ? "running" : session.endTime!.formatted(DateTimeFormat.time)
             let durStr = DurationFormat.formatted(session.duration())

--- a/Tests/AppTests/OutputFormatterTests.swift
+++ b/Tests/AppTests/OutputFormatterTests.swift
@@ -10,14 +10,14 @@ struct OutputFormatterTests {
 
     @Test("started formats project name")
     func startedBasic() {
-        let result = CommandResult.started(project: "Acme Corp", running: [])
+        let result = CommandResult.sessionStarted(project: "Acme Corp", running: [])
         let text = OutputFormatter.formatText(result)
         #expect(text == "Started Acme Corp")
     }
 
     @Test("started includes other running timers")
     func startedWithRunning() {
-        let result = CommandResult.started(project: "Acme Corp", running: ["Project B", "Project C"])
+        let result = CommandResult.sessionStarted(project: "Acme Corp", running: ["Project B", "Project C"])
         let text = OutputFormatter.formatText(result)
         #expect(text == "Started Acme Corp\nCurrently running: Project B, Project C")
     }
@@ -26,7 +26,7 @@ struct OutputFormatterTests {
 
     @Test("stopped formats single entry")
     func stoppedSingle() {
-        let result = CommandResult.stopped(entries: [
+        let result = CommandResult.sessionStopped(entries: [
             StopEntry(name: "Acme Corp", duration: 9000),
         ])
         let text = OutputFormatter.formatText(result)
@@ -35,7 +35,7 @@ struct OutputFormatterTests {
 
     @Test("stopped formats multiple entries with aligned names")
     func stoppedMultiple() {
-        let result = CommandResult.stopped(entries: [
+        let result = CommandResult.sessionStopped(entries: [
             StopEntry(name: "Acme Corp", duration: 9000),
             StopEntry(name: "Side", duration: 3600),
         ])
@@ -48,7 +48,7 @@ struct OutputFormatterTests {
 
     @Test("stopped with no running timers")
     func stoppedNoTimers() {
-        let result = CommandResult.stopped(entries: [])
+        let result = CommandResult.sessionStopped(entries: [])
         let text = OutputFormatter.formatText(result)
         #expect(text == "No timers currently running.")
     }
@@ -59,7 +59,7 @@ struct OutputFormatterTests {
     func status() {
         let project = Project(id: 1, parentId: nil, name: "Acme Corp", slug: "acme-corp", createdAt: Date())
         let statuses = [ProjectStatus(project: project, runningSession: nil)]
-        let result = CommandResult.status(statuses: statuses)
+        let result = CommandResult.sessionStatus(statuses: statuses)
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderStatus(statuses))
     }
@@ -70,7 +70,7 @@ struct OutputFormatterTests {
     func todayTotals() {
         let totals = ProjectTotals(entries: [])
         let period = "Saturday, March 22, 2026"
-        let result = CommandResult.todayTotals(totals: totals, period: period)
+        let result = CommandResult.sessionTodayTotals(totals: totals, period: period)
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderTodayTotals(totals, period: period))
     }
@@ -80,7 +80,7 @@ struct OutputFormatterTests {
     @Test("grouped delegates to Table.renderGrouped")
     func grouped() {
         let report = GroupedReport(columns: ["Mon", "Tue"], rows: [])
-        let result = CommandResult.grouped(report: report, period: "Mar 17 – Mar 22", projectFilter: nil, hoursOnly: false)
+        let result = CommandResult.sessionGrouped(report: report, period: "Mar 17 – Mar 22", projectFilter: nil, hoursOnly: false)
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderGrouped(report, period: "Mar 17 – Mar 22"))
     }
@@ -90,7 +90,7 @@ struct OutputFormatterTests {
     @Test("verbose delegates to Table.renderVerbose")
     func verbose() {
         let sessions: [VerboseSessionRow] = []
-        let result = CommandResult.verbose(sessions: sessions, period: "Mar 22", projectFilter: nil)
+        let result = CommandResult.sessionVerbose(sessions: sessions, period: "Mar 22", projectFilter: nil)
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderVerbose(sessions, period: "Mar 22"))
     }
@@ -102,7 +102,7 @@ struct OutputFormatterTests {
         let start = Date().addingTimeInterval(-7200)
         let stop = Date().addingTimeInterval(-3600)
         let session = Session(id: 42, projectId: 1, startTime: start, endTime: stop)
-        let result = CommandResult.edited(session: session)
+        let result = CommandResult.sessionEdited(session: session)
         let text = OutputFormatter.formatText(result)
         let startStr = start.formatted(DateTimeFormat.time)
         let stopStr = stop.formatted(DateTimeFormat.time)
@@ -114,7 +114,7 @@ struct OutputFormatterTests {
     func editedRunning() {
         let start = Date().addingTimeInterval(-3600)
         let session = Session(id: 42, projectId: 1, startTime: start, endTime: nil)
-        let result = CommandResult.edited(session: session)
+        let result = CommandResult.sessionEdited(session: session)
         let text = OutputFormatter.formatText(result)
         #expect(text.contains("running"))
     }


### PR DESCRIPTION
## Summary

- Add `CommandResult` enum with cases for every command's structured output (started, stopped, status, todayTotals, grouped, verbose, edited, projectList, projectRenamed, dashboard, configValue, configList, message)
- Add `StopEntry` struct for stop command results
- Add `OutputFormatter.formatText()` that renders each case as text, delegating to existing `Table.render*()` and `DashboardRenderer.render()` for complex output
- No commands are changed — this PR only adds the types and formatter

## Test plan

- [x] `swift build` passes
- [x] All 232 tests pass (19 new OutputFormatter tests)
- [x] Text output matches existing rendering for all cases (verified by comparing formatter output against direct `Table.render*()` calls in tests)

Closes #124