### PR TITLE
Fix sessions status crash on duplicate project keys

### DIFF
--- a/Sources/App/Commands/Sessions.swift
+++ b/Sources/App/Commands/Sessions.swift
@@ -84,13 +84,13 @@ struct Sessions: ParsableCommand {
             let running = try ctx.sessionService.list(running: true)
 
             if running.isEmpty {
-                return .sessionStopped(sessions: [], projects: [])
+                return .sessionStopped(stopped: [])
             }
 
             if running.count == 1 {
                 let (session, proj) = running[0]
                 let stopped = try ctx.sessionService.update(id: session.id, startTime: session.startTime, endTime: Date())
-                return .sessionStopped(sessions: [stopped], projects: [proj])
+                return .sessionStopped(stopped: [(session: stopped, projectName: proj.name)])
             }
 
             // Multiple running — interactive prompt
@@ -112,7 +112,7 @@ struct Sessions: ParsableCommand {
                 if let num = Int(input), num >= 1, num <= running.count {
                     let (session, proj) = running[num - 1]
                     let stopped = try ctx.sessionService.update(id: session.id, startTime: session.startTime, endTime: Date())
-                    return .sessionStopped(sessions: [stopped], projects: [proj])
+                    return .sessionStopped(stopped: [(session: stopped, projectName: proj.name)])
                 }
 
                 print("Invalid choice. Try again.")
@@ -128,25 +128,23 @@ struct Sessions: ParsableCommand {
                 throw RockyError.sessionNoTimerRunning(proj.name)
             }
             let stopped = try ctx.sessionService.update(id: session.id, startTime: session.startTime, endTime: Date())
-            return .sessionStopped(sessions: [stopped], projects: [proj])
+            return .sessionStopped(stopped: [(session: stopped, projectName: proj.name)])
         }
 
         private func stopAll(ctx: AppContext) throws -> CommandResult {
             let running = try ctx.sessionService.list(running: true)
             if running.isEmpty {
-                return .sessionStopped(sessions: [], projects: [])
+                return .sessionStopped(stopped: [])
             }
 
             let now = Date()
-            var stoppedSessions: [Session] = []
-            var stoppedProjects: [Project] = []
+            var result: [(session: Session, projectName: String)] = []
             for (session, proj) in running {
                 let stopped = try ctx.sessionService.update(id: session.id, startTime: session.startTime, endTime: now)
-                stoppedSessions.append(stopped)
-                stoppedProjects.append(proj)
+                result.append((session: stopped, projectName: proj.name))
             }
 
-            return .sessionStopped(sessions: stoppedSessions, projects: stoppedProjects)
+            return .sessionStopped(stopped: result)
         }
     }
 
@@ -221,8 +219,8 @@ struct Sessions: ParsableCommand {
                     return .sessionVerbose(sessions: sessions, period: Date().formatted(DateTimeFormat.fullDate), projectFilter: project)
                 } else {
                     let totals = try ctx.reportService.totals(from: start, to: endOfToday, projectId: projectId)
-                    let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: start, to: endOfToday, projectId: projectId)
-                    return .sessionTodayTotals(totals: totals, period: Date().formatted(DateTimeFormat.fullDate), sessions: rawSessions, projects: rawProjects)
+                    let sessions = try ctx.sessionService.list(from: start, to: endOfToday, projectId: projectId).map(\.0)
+                    return .sessionTodayTotals(totals: totals, period: Date().formatted(DateTimeFormat.fullDate), sessions: sessions)
                 }
             }
 
@@ -234,8 +232,8 @@ struct Sessions: ParsableCommand {
                     return .sessionVerbose(sessions: sessions, period: period, projectFilter: project)
                 } else {
                     let report = try ctx.reportService.groupedByDay(from: start, to: endOfToday, projectId: projectId)
-                    let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: start, to: endOfToday, projectId: projectId)
-                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: rawSessions, projects: rawProjects)
+                    let sessions = try ctx.sessionService.list(from: start, to: endOfToday, projectId: projectId).map(\.0)
+                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: sessions)
                 }
             }
 
@@ -247,8 +245,8 @@ struct Sessions: ParsableCommand {
                     return .sessionVerbose(sessions: sessions, period: period, projectFilter: project)
                 } else {
                     let report = try ctx.reportService.groupedByWeekOfMonth(from: start, to: endOfToday, projectId: projectId)
-                    let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: start, to: endOfToday, projectId: projectId)
-                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: rawSessions, projects: rawProjects)
+                    let sessions = try ctx.sessionService.list(from: start, to: endOfToday, projectId: projectId).map(\.0)
+                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: sessions)
                 }
             }
 
@@ -260,8 +258,8 @@ struct Sessions: ParsableCommand {
                     return .sessionVerbose(sessions: sessions, period: period, projectFilter: project)
                 } else {
                     let report = try ctx.reportService.groupedByMonth(from: start, to: endOfToday, projectId: projectId)
-                    let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: start, to: endOfToday, projectId: projectId)
-                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: true, sessions: rawSessions, projects: rawProjects)
+                    let sessions = try ctx.sessionService.list(from: start, to: endOfToday, projectId: projectId).map(\.0)
+                    return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: true, sessions: sessions)
                 }
             }
 
@@ -292,26 +290,17 @@ struct Sessions: ParsableCommand {
                 return .sessionVerbose(sessions: sessions, period: period, projectFilter: project)
             } else if days <= 7 {
                 let report = try ctx.reportService.groupedByDay(from: fromDate, to: toDate, projectId: projectId)
-                let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: fromDate, to: toDate, projectId: projectId)
-                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: rawSessions, projects: rawProjects)
+                let sessions = try ctx.sessionService.list(from: fromDate, to: toDate, projectId: projectId).map(\.0)
+                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: sessions)
             } else if days <= 60 {
                 let report = try ctx.reportService.groupedByWeek(from: fromDate, to: toDate, projectId: projectId)
-                let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: fromDate, to: toDate, projectId: projectId)
-                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: rawSessions, projects: rawProjects)
+                let sessions = try ctx.sessionService.list(from: fromDate, to: toDate, projectId: projectId).map(\.0)
+                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: false, sessions: sessions)
             } else {
                 let report = try ctx.reportService.groupedByMonth(from: fromDate, to: toDate, projectId: projectId)
-                let (rawSessions, rawProjects) = try fetchSessions(ctx: ctx, from: fromDate, to: toDate, projectId: projectId)
-                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: true, sessions: rawSessions, projects: rawProjects)
+                let sessions = try ctx.sessionService.list(from: fromDate, to: toDate, projectId: projectId).map(\.0)
+                return .sessionGrouped(report: report, period: period, projectFilter: project, hoursOnly: true, sessions: sessions)
             }
-        }
-
-        // MARK: - Helpers
-
-        private func fetchSessions(ctx: AppContext, from: Date, to: Date, projectId: Int?) throws -> ([Session], [Project]) {
-            let pairs = try ctx.sessionService.list(from: from, to: to, projectId: projectId)
-            let sessions = pairs.map(\.0)
-            let uniqueProjects = Dictionary(uniqueKeysWithValues: pairs.map { ($0.1.id, $0.1) })
-            return (sessions, Array(uniqueProjects.values))
         }
 
         // MARK: - Date helpers

--- a/Sources/App/Output/CommandResult.swift
+++ b/Sources/App/Output/CommandResult.swift
@@ -4,10 +4,10 @@ import RockyCore
 enum CommandResult {
     // Session
     case sessionStarted(session: Session, project: Project, otherRunning: [String])
-    case sessionStopped(sessions: [Session], projects: [Project])
+    case sessionStopped(stopped: [(session: Session, projectName: String)])
     case sessionStatus(statuses: [ProjectStatus])
-    case sessionTodayTotals(totals: ProjectTotals, period: String, sessions: [Session], projects: [Project])
-    case sessionGrouped(report: GroupedReport, period: String, projectFilter: String?, hoursOnly: Bool, sessions: [Session], projects: [Project])
+    case sessionTodayTotals(totals: ProjectTotals, period: String, sessions: [Session])
+    case sessionGrouped(report: GroupedReport, period: String, projectFilter: String?, hoursOnly: Bool, sessions: [Session])
     case sessionVerbose(sessions: [VerboseSessionRow], period: String, projectFilter: String?)
     case sessionEdited(session: Session)
 

--- a/Sources/App/Output/JSONOutput.swift
+++ b/Sources/App/Output/JSONOutput.swift
@@ -1,7 +1,0 @@
-import Foundation
-import RockyCore
-
-struct SessionsWithProjects: Encodable {
-    let sessions: [Session]
-    let projects: [Project]
-}

--- a/Sources/App/Output/OutputFormatter.swift
+++ b/Sources/App/Output/OutputFormatter.swift
@@ -21,19 +21,20 @@ enum OutputFormatter {
         case .sessionStarted(let session, _, _):
             return encode(["session": session])
 
-        case .sessionStopped(let sessions, let projects):
-            return encode(SessionsWithProjects(sessions: sessions, projects: projects))
+        case .sessionStopped(let stopped):
+            return encode(["sessions": stopped.map(\.session)])
 
         case .sessionStatus(let statuses):
+            struct StatusOutput: Encodable { let sessions: [Session]; let projects: [Project] }
             let projects = statuses.map(\.project)
             let sessions = statuses.compactMap(\.runningSession)
-            return encode(SessionsWithProjects(sessions: sessions, projects: projects))
+            return encode(StatusOutput(sessions: sessions, projects: projects))
 
-        case .sessionTodayTotals(_, _, let sessions, let projects):
-            return encode(SessionsWithProjects(sessions: sessions, projects: projects))
+        case .sessionTodayTotals(_, _, let sessions):
+            return encode(["sessions": sessions])
 
-        case .sessionGrouped(_, _, _, _, let sessions, let projects):
-            return encode(SessionsWithProjects(sessions: sessions, projects: projects))
+        case .sessionGrouped(_, _, _, _, let sessions):
+            return encode(["sessions": sessions])
 
         case .sessionVerbose(let rows, _, _):
             return encode(["sessions": rows.map(\.session)])
@@ -78,32 +79,27 @@ enum OutputFormatter {
             }
             return msg
 
-        case .sessionStopped(let sessions, let projects):
-            if sessions.isEmpty {
+        case .sessionStopped(let stopped):
+            if stopped.isEmpty {
                 return "No timers currently running."
             }
-            let projectById = Dictionary(uniqueKeysWithValues: projects.map { ($0.id, $0) })
-            if sessions.count == 1 {
-                let s = sessions[0]
-                let name = projectById[s.projectId]?.name ?? "Unknown"
-                return "Stopped \(name) (\(DurationFormat.formatted(s.duration())))"
+            if stopped.count == 1 {
+                let entry = stopped[0]
+                return "Stopped \(entry.projectName) (\(DurationFormat.formatted(entry.session.duration())))"
             }
-            let entries = sessions.map { s in
-                (name: projectById[s.projectId]?.name ?? "Unknown", duration: s.duration())
-            }
-            let maxName = entries.map(\.name.count).max() ?? 0
-            return entries.map { entry in
-                let padded = entry.name.padding(toLength: maxName, withPad: " ", startingAt: 0)
-                return "Stopped \(padded)  (\(DurationFormat.formatted(entry.duration)))"
+            let maxName = stopped.map(\.projectName.count).max() ?? 0
+            return stopped.map { entry in
+                let padded = entry.projectName.padding(toLength: maxName, withPad: " ", startingAt: 0)
+                return "Stopped \(padded)  (\(DurationFormat.formatted(entry.session.duration())))"
             }.joined(separator: "\n")
 
         case .sessionStatus(let statuses):
             return Table.renderStatus(statuses)
 
-        case .sessionTodayTotals(let totals, let period, _, _):
+        case .sessionTodayTotals(let totals, let period, _):
             return Table.renderTodayTotals(totals, period: period)
 
-        case .sessionGrouped(let report, let period, let projectFilter, let hoursOnly, _, _):
+        case .sessionGrouped(let report, let period, let projectFilter, let hoursOnly, _):
             return Table.renderGrouped(report, period: period, projectFilter: projectFilter, hoursOnly: hoursOnly)
 
         case .sessionVerbose(let sessions, let period, let projectFilter):

--- a/Tests/AppTests/JSONOutputTests.swift
+++ b/Tests/AppTests/JSONOutputTests.swift
@@ -165,9 +165,8 @@ struct JSONOutputTests {
 
     @Test("sessionStopped returns session models")
     func sessionStopped() throws {
-        let project = Project(id: 1, parentId: nil, name: "Acme Corp", slug: "acme-corp", createdAt: Date())
         let session = Session(id: 5, projectId: 1, startTime: Date().addingTimeInterval(-3600), endTime: Date())
-        let result = CommandResult.sessionStopped(sessions: [session], projects: [project])
+        let result = CommandResult.sessionStopped(stopped: [(session: session, projectName: "Acme Corp")])
         let json = OutputFormatter.formatJSON(result)
         assertValidJSON(json)
         let obj = try decode(json)
@@ -175,8 +174,7 @@ struct JSONOutputTests {
         #expect(sessions.count == 1)
         #expect(sessions[0]["id"] as? Int == 5)
         #expect(sessions[0]["end_time"] as? String != nil)
-        let projects = obj["projects"] as! [[String: Any]]
-        #expect(projects[0]["name"] as? String == "Acme Corp")
+        #expect(sessions[0]["project_id"] as? Int == 1)
     }
 
     // MARK: - Project Renamed

--- a/Tests/AppTests/JSONOutputTests.swift
+++ b/Tests/AppTests/JSONOutputTests.swift
@@ -92,6 +92,38 @@ struct JSONOutputTests {
         #expect(sessions[0]["end_time"] as? String != nil)
     }
 
+    // MARK: - Session Today Totals
+
+    @Test("sessionTodayTotals returns sessions array")
+    func sessionTodayTotals() throws {
+        let session = Session(id: 3, projectId: 1, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let totals = ProjectTotals(entries: [])
+        let result = CommandResult.sessionTodayTotals(totals: totals, period: "Apr 23", sessions: [session])
+        let json = OutputFormatter.formatJSON(result)
+        assertValidJSON(json)
+        let obj = try decode(json)
+        let sessions = obj["sessions"] as! [[String: Any]]
+        #expect(sessions.count == 1)
+        #expect(sessions[0]["id"] as? Int == 3)
+        #expect(sessions[0]["project_id"] as? Int == 1)
+    }
+
+    // MARK: - Session Grouped
+
+    @Test("sessionGrouped returns sessions array")
+    func sessionGrouped() throws {
+        let session = Session(id: 8, projectId: 2, startTime: Date().addingTimeInterval(-7200), endTime: Date())
+        let report = GroupedReport(columns: ["Mon"], rows: [])
+        let result = CommandResult.sessionGrouped(report: report, period: "Apr 21 – Apr 23", projectFilter: nil, hoursOnly: false, sessions: [session])
+        let json = OutputFormatter.formatJSON(result)
+        assertValidJSON(json)
+        let obj = try decode(json)
+        let sessions = obj["sessions"] as! [[String: Any]]
+        #expect(sessions.count == 1)
+        #expect(sessions[0]["id"] as? Int == 8)
+        #expect(sessions[0]["project_id"] as? Int == 2)
+    }
+
     // MARK: - Project List
 
     @Test("projectList returns project models")

--- a/Tests/AppTests/OutputFormatterTests.swift
+++ b/Tests/AppTests/OutputFormatterTests.swift
@@ -30,20 +30,20 @@ struct OutputFormatterTests {
 
     @Test("stopped formats single entry")
     func stoppedSingle() {
-        let project = Project(id: 1, parentId: nil, name: "Acme Corp", slug: "acme-corp", createdAt: Date())
         let session = Session(id: 1, projectId: 1, startTime: Date().addingTimeInterval(-9000), endTime: Date())
-        let result = CommandResult.sessionStopped(sessions: [session], projects: [project])
+        let result = CommandResult.sessionStopped(stopped: [(session: session, projectName: "Acme Corp")])
         let text = OutputFormatter.formatText(result)
         #expect(text == "Stopped Acme Corp (2h 30m)")
     }
 
     @Test("stopped formats multiple entries with aligned names")
     func stoppedMultiple() {
-        let proj1 = Project(id: 1, parentId: nil, name: "Acme Corp", slug: "acme-corp", createdAt: Date())
-        let proj2 = Project(id: 2, parentId: nil, name: "Side", slug: "side", createdAt: Date())
         let s1 = Session(id: 1, projectId: 1, startTime: Date().addingTimeInterval(-9000), endTime: Date())
         let s2 = Session(id: 2, projectId: 2, startTime: Date().addingTimeInterval(-3600), endTime: Date())
-        let result = CommandResult.sessionStopped(sessions: [s1, s2], projects: [proj1, proj2])
+        let result = CommandResult.sessionStopped(stopped: [
+            (session: s1, projectName: "Acme Corp"),
+            (session: s2, projectName: "Side"),
+        ])
         let text = OutputFormatter.formatText(result)
         let lines = text.split(separator: "\n")
         #expect(lines.count == 2)
@@ -53,7 +53,7 @@ struct OutputFormatterTests {
 
     @Test("stopped with no running timers")
     func stoppedNoTimers() {
-        let result = CommandResult.sessionStopped(sessions: [], projects: [])
+        let result = CommandResult.sessionStopped(stopped: [])
         let text = OutputFormatter.formatText(result)
         #expect(text == "No timers currently running.")
     }
@@ -75,7 +75,7 @@ struct OutputFormatterTests {
     func todayTotals() {
         let totals = ProjectTotals(entries: [])
         let period = "Saturday, March 22, 2026"
-        let result = CommandResult.sessionTodayTotals(totals: totals, period: period, sessions: [], projects: [])
+        let result = CommandResult.sessionTodayTotals(totals: totals, period: period, sessions: [])
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderTodayTotals(totals, period: period))
     }
@@ -85,7 +85,7 @@ struct OutputFormatterTests {
     @Test("grouped delegates to Table.renderGrouped")
     func grouped() {
         let report = GroupedReport(columns: ["Mon", "Tue"], rows: [])
-        let result = CommandResult.sessionGrouped(report: report, period: "Mar 17 – Mar 22", projectFilter: nil, hoursOnly: false, sessions: [], projects: [])
+        let result = CommandResult.sessionGrouped(report: report, period: "Mar 17 – Mar 22", projectFilter: nil, hoursOnly: false, sessions: [])
         let text = OutputFormatter.formatText(result)
         #expect(text == Table.renderGrouped(report, period: "Mar 17 – Mar 22"))
     }

--- a/Tests/AppTests/SessionsStopTests.swift
+++ b/Tests/AppTests/SessionsStopTests.swift
@@ -32,12 +32,11 @@ struct SessionsStopTests {
         let cmd = makeStop()
         let result = try cmd.execute(ctx: ctx)
 
-        guard case .sessionStopped(let sessions, let projects) = result else {
+        guard case .sessionStopped(let stopped) = result else {
             Issue.record("Expected .sessionStopped, got \(result)")
             return
         }
-        #expect(sessions.isEmpty)
-        #expect(projects.isEmpty)
+        #expect(stopped.isEmpty)
     }
 
     @Test("stop single running timer returns stopped session")
@@ -53,15 +52,14 @@ struct SessionsStopTests {
         let running = try sessionRepo.list(running: true)
         #expect(running.isEmpty)
 
-        guard case .sessionStopped(let sessions, let projects) = result else {
+        guard case .sessionStopped(let stopped) = result else {
             Issue.record("Expected .sessionStopped, got \(result)")
             return
         }
-        #expect(sessions.count == 1)
-        #expect(sessions[0].endTime != nil)
-        #expect(!sessions[0].isRunning)
-        #expect(projects.count == 1)
-        #expect(projects[0].name == "acme-corp")
+        #expect(stopped.count == 1)
+        #expect(stopped[0].session.endTime != nil)
+        #expect(!stopped[0].session.isRunning)
+        #expect(stopped[0].projectName == "acme-corp")
     }
 
     @Test("stop by project name stops only that project")
@@ -80,12 +78,12 @@ struct SessionsStopTests {
         #expect(running.count == 1)
         #expect(running[0].1.name == "project-b")
 
-        guard case .sessionStopped(let sessions, let projects) = result else {
+        guard case .sessionStopped(let stopped) = result else {
             Issue.record("Expected .sessionStopped, got \(result)")
             return
         }
-        #expect(sessions.count == 1)
-        #expect(projects[0].name == "project-a")
+        #expect(stopped.count == 1)
+        #expect(stopped[0].projectName == "project-a")
     }
 
     @Test("stop --all stops all running timers and returns all sessions")
@@ -103,12 +101,12 @@ struct SessionsStopTests {
         let running = try sessionRepo.list(running: true)
         #expect(running.isEmpty)
 
-        guard case .sessionStopped(let sessions, _) = result else {
+        guard case .sessionStopped(let stopped) = result else {
             Issue.record("Expected .sessionStopped, got \(result)")
             return
         }
-        #expect(sessions.count == 2)
-        #expect(sessions.allSatisfy { !$0.isRunning })
+        #expect(stopped.count == 2)
+        #expect(stopped.allSatisfy { !$0.session.isRunning })
     }
 
     @Test("stop by project name throws when project not found")
@@ -174,10 +172,10 @@ struct SessionsStopTests {
         let cmd = makeStop(all: true)
         let result = try cmd.execute(ctx: ctx)
 
-        guard case .sessionStopped(let sessions, _) = result else {
+        guard case .sessionStopped(let stopped) = result else {
             Issue.record("Expected .sessionStopped, got \(result)")
             return
         }
-        #expect(sessions.isEmpty)
+        #expect(stopped.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- Remove `fetchSessions` helper and `SessionsWithProjects` struct — the `Dictionary(uniqueKeysWithValues:)` call crashed when multiple sessions belonged to the same project
- `sessionStopped` now carries paired `(session, projectName)` tuples instead of two disconnected arrays
- JSON output for time-range queries (`--today`, `--week`, `--month`, `--year`, `--from`) and stop commands now encodes sessions directly with `project_id` — no separate projects array
- `sessionStatus` (no time-range flags) still returns both sessions and projects, since it reports which projects exist and which have running timers

Closes #137

## Test plan
- [x] All 279 tests pass (2 new JSON output tests for todayTotals and grouped)
- [x] Manual smoke test: `swift run App sessions status --today`