### PR TITLE
Add delete commands for sessions and projects

### DIFF
--- a/Sources/App/Commands/Projects.swift
+++ b/Sources/App/Commands/Projects.swift
@@ -4,7 +4,7 @@ import RockyCore
 struct Projects: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Manage projects.",
-        subcommands: [List.self, Rename.self]
+        subcommands: [List.self, Rename.self, Delete.self]
     )
 
     struct List: ParsableCommand {
@@ -60,6 +60,88 @@ struct Projects: ParsableCommand {
         func execute(ctx: AppContext) throws -> CommandResult {
             let renamed = try ctx.projectService.rename(oldName: oldName, newName: newName)
             return .projectRenamed(oldName: oldName, project: renamed)
+        }
+    }
+
+    struct Delete: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Delete a project and all its sessions."
+        )
+
+        @Argument(help: "The project name to delete.")
+        var name: String?
+
+        @Flag(name: .long, help: "Skip confirmation prompt.")
+        var confirm: Bool = false
+
+        @OptionGroup var outputOptions: OutputOptions
+
+        func run() throws {
+            do {
+                let ctx = try AppContext.build()
+                let result = try execute(ctx: ctx)
+                output(result, options: outputOptions)
+            } catch let error as RockyError {
+                outputError(error, options: outputOptions)
+                throw ExitCode.failure
+            }
+        }
+
+        @discardableResult
+        func execute(ctx: AppContext) throws -> CommandResult {
+            let projectName: String
+            if let name {
+                projectName = name
+            } else {
+                projectName = try interactive(ctx: ctx)
+            }
+
+            guard let project = try ctx.projectService.get(name: projectName) else {
+                throw RockyError.projectNotFound(projectName)
+            }
+
+            let sessions = try ctx.sessionService.list(projectId: project.id)
+            let sessionCount = sessions.count
+
+            if !confirm {
+                print()
+                print("Delete project \"\(project.name)\" and \(sessionCount) sessions? (y/N): ", terminator: "")
+                guard let line = readLine() else {
+                    throw RockyError.sessionInputCancelled
+                }
+                let input = line.trimmingCharacters(in: .whitespaces).lowercased()
+                if input != "y" && input != "yes" {
+                    return .message("Cancelled.")
+                }
+            }
+
+            let deletedCount = try ctx.projectService.delete(name: projectName, sessionService: ctx.sessionService)
+            return .projectDeleted(project: project, sessionCount: deletedCount)
+        }
+
+        private func interactive(ctx: AppContext) throws -> String {
+            let projects = try ctx.projectService.list()
+
+            if projects.isEmpty {
+                throw RockyError.projectNotFound("")
+            }
+
+            print()
+            print(Table.renderProjects(projects))
+            print()
+
+            while true {
+                print("Delete which? ", terminator: "")
+                guard let line = readLine() else {
+                    throw RockyError.sessionInputCancelled
+                }
+                let input = line.trimmingCharacters(in: .whitespaces)
+                if input.isEmpty {
+                    print("Enter a project name.")
+                    continue
+                }
+                return input
+            }
         }
     }
 }

--- a/Sources/App/Commands/Sessions.swift
+++ b/Sources/App/Commands/Sessions.swift
@@ -5,7 +5,7 @@ import RockyCore
 struct Sessions: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Manage sessions.",
-        subcommands: [Start.self, Stop.self, Status.self, Edit.self]
+        subcommands: [Start.self, Stop.self, Status.self, Edit.self, Delete.self]
     )
 
     struct Start: ParsableCommand {
@@ -607,5 +607,88 @@ struct Sessions: ParsableCommand {
             }
         }
 
+    }
+
+    struct Delete: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Delete a session."
+        )
+
+        @Argument(help: "The session ID to delete.")
+        var id: Int?
+
+        @OptionGroup var outputOptions: OutputOptions
+
+        func run() throws {
+            do {
+                let ctx = try AppContext.build()
+                let result = try execute(ctx: ctx)
+                output(result, options: outputOptions)
+            } catch let error as RockyError {
+                outputError(error, options: outputOptions)
+                throw ExitCode.failure
+            }
+        }
+
+        @discardableResult
+        func execute(ctx: AppContext) throws -> CommandResult {
+            if let sessionId = id {
+                return try deleteById(sessionId, ctx: ctx)
+            } else {
+                return try interactive(ctx: ctx)
+            }
+        }
+
+        private func deleteById(_ sessionId: Int, ctx: AppContext) throws -> CommandResult {
+            guard let session = try ctx.sessionService.get(id: sessionId) else {
+                throw RockyError.sessionNotFound(sessionId)
+            }
+            guard let project = try ctx.projectService.get(id: session.projectId) else {
+                throw RockyError.invalidRow("projects")
+            }
+            try ctx.sessionService.delete(id: sessionId)
+            return .sessionDeleted(session: session, projectName: project.name)
+        }
+
+        private func interactive(ctx: AppContext) throws -> CommandResult {
+            let calendar = Calendar.current
+            let to = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: Date()))!
+            let from = calendar.date(byAdding: .day, value: -90, to: to)!
+            let sessions = try ctx.sessionService.list(from: from, to: to)
+
+            if sessions.isEmpty {
+                return .message("No sessions found.")
+            }
+
+            let verboseRows = sessions.map { session, project in
+                VerboseSessionRow(session: session, projectName: project.name)
+            }
+            let period = DateTimeFormat.periodRange(from: from, to: to)
+            print()
+            print(Table.renderVerbose(verboseRows, period: period, projectFilter: nil))
+            print()
+
+            let sessionId = try promptForSessionId(sessions: sessions.map(\.0))
+            return try deleteById(sessionId, ctx: ctx)
+        }
+
+        private func promptForSessionId(sessions: [Session]) throws -> Int {
+            let validIds = Set(sessions.map(\.id))
+            while true {
+                print("Delete which? ", terminator: "")
+                guard let line = readLine() else {
+                    throw RockyError.sessionInputCancelled
+                }
+                let input = line.trimmingCharacters(in: .whitespaces)
+                guard let id = Int(input) else {
+                    print("Invalid input. Enter a session ID.")
+                    continue
+                }
+                if validIds.contains(id) {
+                    return id
+                }
+                print("No session with ID \(id). Try again.")
+            }
+        }
     }
 }

--- a/Sources/App/Output/CommandResult.swift
+++ b/Sources/App/Output/CommandResult.swift
@@ -10,10 +10,12 @@ enum CommandResult {
     case sessionGrouped(report: GroupedReport, period: String, projectFilter: String?, hoursOnly: Bool, sessions: [Session])
     case sessionVerbose(sessions: [VerboseSessionRow], period: String, projectFilter: String?)
     case sessionEdited(session: Session)
+    case sessionDeleted(session: Session, projectName: String)
 
     // Project
     case projectList(projects: [Project])
     case projectRenamed(oldName: String, project: Project)
+    case projectDeleted(project: Project, sessionCount: Int)
 
     // Dashboard
     case dashboard(data: DashboardData)

--- a/Sources/App/Output/OutputFormatter.swift
+++ b/Sources/App/Output/OutputFormatter.swift
@@ -42,11 +42,18 @@ enum OutputFormatter {
         case .sessionEdited(let session):
             return encode(["session": session])
 
+        case .sessionDeleted(let session, _):
+            return encode(["session": session])
+
         case .projectList(let projects):
             return encode(["projects": projects])
 
         case .projectRenamed(_, let project):
             return encode(["project": project])
+
+        case .projectDeleted(let project, let sessionCount):
+            struct DeletedOutput: Encodable { let project: Project; let sessions_deleted: Int }
+            return encode(DeletedOutput(project: project, sessions_deleted: sessionCount))
 
         case .dashboard:
             return encode(["message": formatText(result)])
@@ -111,6 +118,9 @@ enum OutputFormatter {
             let durStr = DurationFormat.formatted(session.duration())
             return "Updated: \(session.startTime.formatted(DateTimeFormat.dateWithDay))  \(startStr) — \(stopStr)  (\(durStr))"
 
+        case .sessionDeleted(let session, let projectName):
+            return "Deleted session \(session.id) (\(projectName), \(DurationFormat.formatted(session.duration())))"
+
         case .projectList(let projects):
             if projects.isEmpty {
                 return "No projects found."
@@ -119,6 +129,9 @@ enum OutputFormatter {
 
         case .projectRenamed(let oldName, let project):
             return "Renamed \(oldName) → \(project.name)"
+
+        case .projectDeleted(let project, let sessionCount):
+            return "Deleted project \(project.name) (\(sessionCount) sessions removed)"
 
         case .dashboard(let data):
             return DashboardRenderer.render(data)

--- a/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/Mock/MockProjectRepository.swift
@@ -47,4 +47,11 @@ public final class MockProjectRepository: ProjectRepository, @unchecked Sendable
         projects[index] = updated
         return updated
     }
+
+    public func delete(id: Int) throws {
+        guard let index = projects.firstIndex(where: { $0.id == id }) else {
+            throw RockyError.projectNotFound(String(id))
+        }
+        projects.remove(at: index)
+    }
 }

--- a/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
+++ b/Sources/RockyCore/Repositories/Mock/MockSessionRepository.swift
@@ -54,4 +54,18 @@ public final class MockSessionRepository: SessionRepository, @unchecked Sendable
         sessions[index] = updated
         return updated
     }
+
+    public func delete(id: Int) throws {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else {
+            throw RockyError.sessionNotFound(id)
+        }
+        sessions.remove(at: index)
+    }
+
+    @discardableResult
+    public func deleteAll(projectId: Int) throws -> Int {
+        let count = sessions.filter { $0.projectId == projectId }.count
+        sessions.removeAll { $0.projectId == projectId }
+        return count
+    }
 }

--- a/Sources/RockyCore/Repositories/ProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/ProjectRepository.swift
@@ -6,4 +6,5 @@ public protocol ProjectRepository: Sendable {
     func get(slug: String) throws -> Project?
     func list() throws -> [Project]
     func update(id: Int, name: String, slug: String) throws -> Project
+    func delete(id: Int) throws
 }

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteProjectRepository.swift
@@ -74,4 +74,17 @@ public struct SQLiteProjectRepository: ProjectRepository, Sendable {
             return updated
         }
     }
+
+    public func delete(id: Int) throws {
+        try db.dbQueue.write { db in
+            guard try Project.fetchOne(db,
+                sql: "SELECT * FROM projects WHERE id = ?",
+                arguments: [id]) != nil else {
+                throw RockyError.projectNotFound(String(id))
+            }
+            try db.execute(
+                sql: "DELETE FROM projects WHERE id = ?",
+                arguments: [id])
+        }
+    }
 }

--- a/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
+++ b/Sources/RockyCore/Repositories/SQLite/SQLiteSessionRepository.swift
@@ -89,4 +89,30 @@ public struct SQLiteSessionRepository: SessionRepository, Sendable {
                 arguments: [id])!
         }
     }
+
+    public func delete(id: Int) throws {
+        try db.dbQueue.write { db in
+            guard try Session.fetchOne(db,
+                sql: "SELECT * FROM sessions WHERE id = ?",
+                arguments: [id]) != nil else {
+                throw RockyError.sessionNotFound(id)
+            }
+            try db.execute(
+                sql: "DELETE FROM sessions WHERE id = ?",
+                arguments: [id])
+        }
+    }
+
+    @discardableResult
+    public func deleteAll(projectId: Int) throws -> Int {
+        try db.dbQueue.write { db in
+            let count = try Int.fetchOne(db,
+                sql: "SELECT COUNT(*) FROM sessions WHERE project_id = ?",
+                arguments: [projectId]) ?? 0
+            try db.execute(
+                sql: "DELETE FROM sessions WHERE project_id = ?",
+                arguments: [projectId])
+            return count
+        }
+    }
 }

--- a/Sources/RockyCore/Repositories/SessionRepository.swift
+++ b/Sources/RockyCore/Repositories/SessionRepository.swift
@@ -5,4 +5,6 @@ public protocol SessionRepository: Sendable {
     func get(id: Int) throws -> Session?
     func list(running: Bool?, from: Date?, to: Date?, projectId: Int?) throws -> [(Session, Project)]
     func update(id: Int, startTime: Date, endTime: Date?) throws -> Session
+    func delete(id: Int) throws
+    func deleteAll(projectId: Int) throws -> Int
 }

--- a/Sources/RockyCore/Services/ProjectService.swift
+++ b/Sources/RockyCore/Services/ProjectService.swift
@@ -23,6 +23,16 @@ public struct ProjectService: Sendable {
         try repository.list()
     }
 
+    @discardableResult
+    public func delete(name: String, sessionService: SessionService) throws -> Int {
+        guard let project = try repository.get(slug: name.slugified) else {
+            throw RockyError.projectNotFound(name)
+        }
+        let count = try sessionService.deleteAll(projectId: project.id)
+        try repository.delete(id: project.id)
+        return count
+    }
+
     public func rename(oldName: String, newName: String) throws -> Project {
         guard let project = try repository.get(slug: oldName.slugified) else {
             throw RockyError.projectNotFound(oldName)

--- a/Sources/RockyCore/Services/SessionService.swift
+++ b/Sources/RockyCore/Services/SessionService.swift
@@ -23,4 +23,13 @@ public struct SessionService: Sendable {
     public func update(id: Int, startTime: Date, endTime: Date?) throws -> Session {
         try repository.update(id: id, startTime: startTime, endTime: endTime)
     }
+
+    public func delete(id: Int) throws {
+        try repository.delete(id: id)
+    }
+
+    @discardableResult
+    public func deleteAll(projectId: Int) throws -> Int {
+        try repository.deleteAll(projectId: projectId)
+    }
 }

--- a/Tests/AppTests/JSONOutputTests.swift
+++ b/Tests/AppTests/JSONOutputTests.swift
@@ -124,6 +124,34 @@ struct JSONOutputTests {
         #expect(sessions[0]["project_id"] as? Int == 2)
     }
 
+    // MARK: - Session Deleted
+
+    @Test("sessionDeleted returns session model")
+    func sessionDeleted() throws {
+        let session = Session(id: 41, projectId: 1, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let result = CommandResult.sessionDeleted(session: session, projectName: "acme-corp")
+        let json = OutputFormatter.formatJSON(result)
+        assertValidJSON(json)
+        let obj = try decode(json)
+        let sessionJSON = obj["session"] as! [String: Any]
+        #expect(sessionJSON["id"] as? Int == 41)
+        #expect(sessionJSON["project_id"] as? Int == 1)
+    }
+
+    // MARK: - Project Deleted
+
+    @Test("projectDeleted returns project model and session count")
+    func projectDeleted() throws {
+        let project = Project(id: 1, parentId: nil, name: "acme-corp", slug: "acme-corp", createdAt: Date())
+        let result = CommandResult.projectDeleted(project: project, sessionCount: 47)
+        let json = OutputFormatter.formatJSON(result)
+        assertValidJSON(json)
+        let obj = try decode(json)
+        let projectJSON = obj["project"] as! [String: Any]
+        #expect(projectJSON["name"] as? String == "acme-corp")
+        #expect(obj["sessions_deleted"] as? Int == 47)
+    }
+
     // MARK: - Project List
 
     @Test("projectList returns project models")

--- a/Tests/AppTests/OutputFormatterTests.swift
+++ b/Tests/AppTests/OutputFormatterTests.swift
@@ -153,6 +153,34 @@ struct OutputFormatterTests {
         #expect(text == "Renamed acme-corp → Acme Inc")
     }
 
+    // MARK: - Session deleted
+
+    @Test("sessionDeleted formats confirmation message")
+    func sessionDeleted() {
+        let session = Session(id: 41, projectId: 1, startTime: Date().addingTimeInterval(-9000), endTime: Date())
+        let result = CommandResult.sessionDeleted(session: session, projectName: "acme-corp")
+        let text = OutputFormatter.formatText(result)
+        #expect(text == "Deleted session 41 (acme-corp, 2h 30m)")
+    }
+
+    // MARK: - Project deleted
+
+    @Test("projectDeleted formats confirmation message")
+    func projectDeleted() {
+        let project = Project(id: 1, parentId: nil, name: "acme-corp", slug: "acme-corp", createdAt: Date())
+        let result = CommandResult.projectDeleted(project: project, sessionCount: 47)
+        let text = OutputFormatter.formatText(result)
+        #expect(text == "Deleted project acme-corp (47 sessions removed)")
+    }
+
+    @Test("projectDeleted formats zero sessions")
+    func projectDeletedNoSessions() {
+        let project = Project(id: 1, parentId: nil, name: "acme-corp", slug: "acme-corp", createdAt: Date())
+        let result = CommandResult.projectDeleted(project: project, sessionCount: 0)
+        let text = OutputFormatter.formatText(result)
+        #expect(text == "Deleted project acme-corp (0 sessions removed)")
+    }
+
     // MARK: - Dashboard
 
     @Test("dashboard delegates to DashboardRenderer")

--- a/Tests/AppTests/ProjectsDeleteTests.swift
+++ b/Tests/AppTests/ProjectsDeleteTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import App
+@testable import RockyCore
+
+@Suite("Projects.Delete Command")
+struct ProjectsDeleteTests {
+
+    private func buildCtx() -> (AppContext, MockProjectRepository, MockSessionRepository) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let ctx = AppContext(
+            projectService: ProjectService(repository: projectRepo),
+            sessionService: SessionService(repository: sessionRepo),
+            reportService: ReportService(sessionRepository: sessionRepo, projectRepository: projectRepo),
+            dashboardService: DashboardService(sessionRepository: sessionRepo, projectRepository: projectRepo)
+        )
+        return (ctx, projectRepo, sessionRepo)
+    }
+
+    @Test("delete by name with confirm removes project and sessions")
+    func deleteByNameWithConfirm() throws {
+        let (ctx, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        _ = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        _ = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        var cmd = Projects.Delete()
+        cmd.name = "acme-corp"
+        cmd.confirm = true
+        let result = try cmd.execute(ctx: ctx)
+
+        guard case .projectDeleted(let project, let sessionCount) = result else {
+            Issue.record("Expected .projectDeleted, got \(result)")
+            return
+        }
+        #expect(project.name == "acme-corp")
+        #expect(sessionCount == 2)
+        #expect(try projectRepo.get(id: proj.id) == nil)
+    }
+
+    @Test("delete removes all associated sessions")
+    func deleteRemovesSessions() throws {
+        let (ctx, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let s1 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let s2 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        var cmd = Projects.Delete()
+        cmd.name = "acme-corp"
+        cmd.confirm = true
+        _ = try cmd.execute(ctx: ctx)
+
+        #expect(try sessionRepo.get(id: s1.id) == nil)
+        #expect(try sessionRepo.get(id: s2.id) == nil)
+    }
+
+    @Test("delete does not affect other projects")
+    func deleteDoesNotAffectOthers() throws {
+        let (ctx, projectRepo, sessionRepo) = buildCtx()
+        let proj1 = try projectRepo.create(name: "project-a", slug: "project-a")
+        let proj2 = try projectRepo.create(name: "project-b", slug: "project-b")
+        _ = try sessionRepo.create(projectId: proj1.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let s2 = try sessionRepo.create(projectId: proj2.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        var cmd = Projects.Delete()
+        cmd.name = "project-a"
+        cmd.confirm = true
+        _ = try cmd.execute(ctx: ctx)
+
+        #expect(try projectRepo.get(id: proj2.id) != nil)
+        #expect(try sessionRepo.get(id: s2.id) != nil)
+    }
+
+    @Test("delete throws for unknown project")
+    func deleteUnknownProject() throws {
+        let (ctx, _, _) = buildCtx()
+
+        var cmd = Projects.Delete()
+        cmd.name = "nonexistent"
+        cmd.confirm = true
+        #expect(throws: RockyError.projectNotFound("nonexistent")) {
+            try cmd.execute(ctx: ctx)
+        }
+    }
+
+    @Test("delete project with no sessions returns zero count")
+    func deleteProjectNoSessions() throws {
+        let (ctx, projectRepo, _) = buildCtx()
+        _ = try projectRepo.create(name: "empty", slug: "empty")
+
+        var cmd = Projects.Delete()
+        cmd.name = "empty"
+        cmd.confirm = true
+        let result = try cmd.execute(ctx: ctx)
+
+        guard case .projectDeleted(_, let sessionCount) = result else {
+            Issue.record("Expected .projectDeleted, got \(result)")
+            return
+        }
+        #expect(sessionCount == 0)
+    }
+
+    // MARK: - Parsing
+
+    @Test("rocky projects delete parses name argument")
+    func parsesName() throws {
+        let cmd = try Rocky.parseAsRoot(["projects", "delete", "acme-corp"])
+        #expect(cmd is Projects.Delete)
+        let del = cmd as! Projects.Delete
+        #expect(del.name == "acme-corp")
+    }
+
+    @Test("rocky projects delete parses with no arguments")
+    func parsesNoArgs() throws {
+        let cmd = try Rocky.parseAsRoot(["projects", "delete"])
+        #expect(cmd is Projects.Delete)
+        let del = cmd as! Projects.Delete
+        #expect(del.name == nil)
+    }
+
+    @Test("rocky projects delete parses --confirm flag")
+    func parsesConfirm() throws {
+        let cmd = try Rocky.parseAsRoot(["projects", "delete", "acme-corp", "--confirm"])
+        let del = cmd as! Projects.Delete
+        #expect(del.confirm == true)
+    }
+
+    @Test("rocky projects delete parses --output json")
+    func parsesOutputJson() throws {
+        let cmd = try Rocky.parseAsRoot(["projects", "delete", "acme-corp", "--output", "json"])
+        let del = cmd as! Projects.Delete
+        #expect(del.outputOptions.output == .json)
+    }
+}

--- a/Tests/AppTests/SessionsDeleteTests.swift
+++ b/Tests/AppTests/SessionsDeleteTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import App
+@testable import RockyCore
+
+@Suite("Sessions.Delete Command")
+struct SessionsDeleteTests {
+
+    private func buildCtx() -> (AppContext, MockProjectRepository, MockSessionRepository) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let ctx = AppContext(
+            projectService: ProjectService(repository: projectRepo),
+            sessionService: SessionService(repository: sessionRepo),
+            reportService: ReportService(sessionRepository: sessionRepo, projectRepository: projectRepo),
+            dashboardService: DashboardService(sessionRepository: sessionRepo, projectRepository: projectRepo)
+        )
+        return (ctx, projectRepo, sessionRepo)
+    }
+
+    @Test("delete by id removes session and returns result")
+    func deleteById() throws {
+        let (ctx, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let session = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+
+        var cmd = Sessions.Delete()
+        cmd.id = session.id
+        let result = try cmd.execute(ctx: ctx)
+
+        guard case .sessionDeleted(let deleted, let projectName) = result else {
+            Issue.record("Expected .sessionDeleted, got \(result)")
+            return
+        }
+        #expect(deleted.id == session.id)
+        #expect(projectName == "acme-corp")
+        #expect(try sessionRepo.get(id: session.id) == nil)
+    }
+
+    @Test("delete running session succeeds")
+    func deleteRunningSession() throws {
+        let (ctx, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let session = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: nil)
+
+        var cmd = Sessions.Delete()
+        cmd.id = session.id
+        let result = try cmd.execute(ctx: ctx)
+
+        guard case .sessionDeleted(let deleted, _) = result else {
+            Issue.record("Expected .sessionDeleted, got \(result)")
+            return
+        }
+        #expect(deleted.id == session.id)
+        #expect(try sessionRepo.get(id: session.id) == nil)
+    }
+
+    @Test("delete throws for unknown id")
+    func deleteUnknownId() throws {
+        let (ctx, _, _) = buildCtx()
+
+        var cmd = Sessions.Delete()
+        cmd.id = 999
+        #expect(throws: RockyError.sessionNotFound(999)) {
+            try cmd.execute(ctx: ctx)
+        }
+    }
+
+    @Test("delete error formats as structured JSON")
+    func deleteErrorJSON() throws {
+        let error = RockyError.sessionNotFound(999)
+        let json = OutputFormatter.formatError(error)
+        let data = json.data(using: .utf8)!
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let errorObj = obj["error"] as! [String: Any]
+        #expect(errorObj["code"] as? String == "session_not_found")
+    }
+
+    // MARK: - Parsing
+
+    @Test("rocky sessions delete parses id argument")
+    func parsesId() throws {
+        let cmd = try Rocky.parseAsRoot(["sessions", "delete", "41"])
+        #expect(cmd is Sessions.Delete)
+        let del = cmd as! Sessions.Delete
+        #expect(del.id == 41)
+    }
+
+    @Test("rocky sessions delete parses with no arguments")
+    func parsesNoArgs() throws {
+        let cmd = try Rocky.parseAsRoot(["sessions", "delete"])
+        #expect(cmd is Sessions.Delete)
+        let del = cmd as! Sessions.Delete
+        #expect(del.id == nil)
+    }
+
+    @Test("rocky sessions delete parses --output json")
+    func parsesOutputJson() throws {
+        let cmd = try Rocky.parseAsRoot(["sessions", "delete", "41", "--output", "json"])
+        let del = cmd as! Sessions.Delete
+        #expect(del.outputOptions.output == .json)
+    }
+}

--- a/Tests/RockyCoreTests/DeleteTests.swift
+++ b/Tests/RockyCoreTests/DeleteTests.swift
@@ -1,0 +1,196 @@
+import Testing
+import Foundation
+@testable import RockyCore
+
+@Suite("SessionRepository delete")
+struct SessionRepositoryDeleteTests {
+
+    private func buildRepos() -> (MockProjectRepository, MockSessionRepository) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        return (projectRepo, sessionRepo)
+    }
+
+    @Test("delete removes session by id")
+    func deleteRemovesSession() throws {
+        let (projectRepo, sessionRepo) = buildRepos()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let session = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+
+        try sessionRepo.delete(id: session.id)
+
+        let found = try sessionRepo.get(id: session.id)
+        #expect(found == nil)
+    }
+
+    @Test("delete throws for unknown id")
+    func deleteUnknownId() throws {
+        let (_, sessionRepo) = buildRepos()
+
+        #expect(throws: RockyError.sessionNotFound(999)) {
+            try sessionRepo.delete(id: 999)
+        }
+    }
+
+    @Test("delete running session succeeds")
+    func deleteRunningSession() throws {
+        let (projectRepo, sessionRepo) = buildRepos()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let session = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: nil)
+
+        try sessionRepo.delete(id: session.id)
+
+        let found = try sessionRepo.get(id: session.id)
+        #expect(found == nil)
+    }
+
+    @Test("delete does not affect other sessions")
+    func deleteDoesNotAffectOthers() throws {
+        let (projectRepo, sessionRepo) = buildRepos()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let s1 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-7200), endTime: Date().addingTimeInterval(-3600))
+        let s2 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+
+        try sessionRepo.delete(id: s1.id)
+
+        #expect(try sessionRepo.get(id: s1.id) == nil)
+        #expect(try sessionRepo.get(id: s2.id) != nil)
+    }
+}
+
+@Suite("ProjectRepository delete")
+struct ProjectRepositoryDeleteTests {
+
+    @Test("delete removes project by id")
+    func deleteRemovesProject() throws {
+        let repo = MockProjectRepository()
+        let proj = try repo.create(name: "acme-corp", slug: "acme-corp")
+
+        try repo.delete(id: proj.id)
+
+        let found = try repo.get(id: proj.id)
+        #expect(found == nil)
+    }
+
+    @Test("delete throws for unknown id")
+    func deleteUnknownId() throws {
+        let repo = MockProjectRepository()
+
+        #expect(throws: RockyError.projectNotFound("999")) {
+            try repo.delete(id: 999)
+        }
+    }
+
+    @Test("delete does not affect other projects")
+    func deleteDoesNotAffectOthers() throws {
+        let repo = MockProjectRepository()
+        let p1 = try repo.create(name: "project-a", slug: "project-a")
+        let p2 = try repo.create(name: "project-b", slug: "project-b")
+
+        try repo.delete(id: p1.id)
+
+        #expect(try repo.get(id: p1.id) == nil)
+        #expect(try repo.get(id: p2.id) != nil)
+    }
+}
+
+@Suite("SessionService delete")
+struct SessionServiceDeleteTests {
+
+    private func buildCtx() -> (SessionService, MockProjectRepository, MockSessionRepository) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let service = SessionService(repository: sessionRepo)
+        return (service, projectRepo, sessionRepo)
+    }
+
+    @Test("delete removes session")
+    func deleteRemovesSession() throws {
+        let (service, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let session = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+
+        try service.delete(id: session.id)
+
+        #expect(try sessionRepo.get(id: session.id) == nil)
+    }
+
+    @Test("delete throws for unknown id")
+    func deleteUnknownId() throws {
+        let (service, _, _) = buildCtx()
+
+        #expect(throws: RockyError.sessionNotFound(999)) {
+            try service.delete(id: 999)
+        }
+    }
+}
+
+@Suite("ProjectService delete")
+struct ProjectServiceDeleteTests {
+
+    private func buildCtx() -> (ProjectService, SessionService, MockProjectRepository, MockSessionRepository) {
+        let projectRepo = MockProjectRepository()
+        let sessionRepo = MockSessionRepository(projectRepository: projectRepo)
+        let projectService = ProjectService(repository: projectRepo)
+        let sessionService = SessionService(repository: sessionRepo)
+        return (projectService, sessionService, projectRepo, sessionRepo)
+    }
+
+    @Test("delete removes project and returns session count")
+    func deleteRemovesProject() throws {
+        let (projectService, sessionService, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        _ = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        _ = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        let count = try projectService.delete(name: "acme-corp", sessionService: sessionService)
+
+        #expect(count == 2)
+        #expect(try projectRepo.get(id: proj.id) == nil)
+    }
+
+    @Test("delete removes associated sessions")
+    func deleteRemovesSessions() throws {
+        let (projectService, sessionService, projectRepo, sessionRepo) = buildCtx()
+        let proj = try projectRepo.create(name: "acme-corp", slug: "acme-corp")
+        let s1 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let s2 = try sessionRepo.create(projectId: proj.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        _ = try projectService.delete(name: "acme-corp", sessionService: sessionService)
+
+        #expect(try sessionRepo.get(id: s1.id) == nil)
+        #expect(try sessionRepo.get(id: s2.id) == nil)
+    }
+
+    @Test("delete does not affect other project sessions")
+    func deleteDoesNotAffectOtherSessions() throws {
+        let (projectService, sessionService, projectRepo, sessionRepo) = buildCtx()
+        let proj1 = try projectRepo.create(name: "project-a", slug: "project-a")
+        let proj2 = try projectRepo.create(name: "project-b", slug: "project-b")
+        _ = try sessionRepo.create(projectId: proj1.id, startTime: Date().addingTimeInterval(-3600), endTime: Date())
+        let s2 = try sessionRepo.create(projectId: proj2.id, startTime: Date().addingTimeInterval(-1800), endTime: Date())
+
+        _ = try projectService.delete(name: "project-a", sessionService: sessionService)
+
+        #expect(try sessionRepo.get(id: s2.id) != nil)
+    }
+
+    @Test("delete throws for unknown project")
+    func deleteUnknownProject() throws {
+        let (projectService, sessionService, _, _) = buildCtx()
+
+        #expect(throws: RockyError.projectNotFound("nonexistent")) {
+            try projectService.delete(name: "nonexistent", sessionService: sessionService)
+        }
+    }
+
+    @Test("delete project with no sessions returns zero count")
+    func deleteProjectNoSessions() throws {
+        let (projectService, sessionService, projectRepo, _) = buildCtx()
+        _ = try projectRepo.create(name: "empty-project", slug: "empty-project")
+
+        let count = try projectService.delete(name: "empty-project", sessionService: sessionService)
+
+        #expect(count == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `rocky sessions delete [id]` — delete by ID or interactive picker
- Add `rocky projects delete [name] [--confirm]` — delete project and all sessions, with confirmation prompt
- Full stack: repository delete methods, service layer with cascading delete, commands, output formatting
- 35 new tests, all passing (314 total)

### Not yet implemented
- Verbose project list for interactive delete (#142)
- `--project` filter on `sessions delete`
- `projects delete` by numeric ID

These are blocked on #142 (verbose-by-default output) and will be addressed there.

Partial #119

## Test plan
- [x] 314 tests pass (35 new)
- [x] Manual smoke test of both commands